### PR TITLE
Device disambiguation logic

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="$USER_HOME$/.sdkman/candidates/gradle/current" />
+        <option name="gradleJvm" value="corretto-21" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="temurin-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="corretto-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/kotlin/DeviceManager.kt
+++ b/src/main/kotlin/DeviceManager.kt
@@ -87,7 +87,7 @@ class DeviceAbbreviator {
     fun abbreviate() {
         while (appendNextTokensToAbbreviations()) {
             shortenAbbreviations()
-            updateMinAbbrevLength()
+            updatePrevAbbrevLength()
         }
         closedForAdditions = true
     }
@@ -110,7 +110,7 @@ class DeviceAbbreviator {
         return appended
     }
 
-    private fun updateMinAbbrevLength() {
+    private fun updatePrevAbbrevLength() {
         for ((i, abbreviation) in abbreviations.withIndex()) {
             previousAbbreviationLength[i] = abbreviation.length
         }

--- a/src/main/kotlin/DeviceManager.kt
+++ b/src/main/kotlin/DeviceManager.kt
@@ -122,8 +122,9 @@ class DeviceAbbreviator {
         uniqueAbbreviations.addAll(abbreviations)
 
         for ((i, abbreviation) in this.abbreviations.withIndex()) {
-            if (abbreviation in abbreviationCache) {
-                this.abbreviations[i] = abbreviationCache[abbreviation]!!
+            val cachedAbbreviation = abbreviationCache[abbreviation]
+            if (cachedAbbreviation != null) {
+                this.abbreviations[i] = cachedAbbreviation
                 continue
             }
             uniqueAbbreviations.remove(abbreviation)

--- a/src/main/kotlin/DeviceManager.kt
+++ b/src/main/kotlin/DeviceManager.kt
@@ -31,11 +31,8 @@ class DeviceManager(deviceListJson: String) {
         for (device in devices) {
             val fullName = device.label.lowercase()
             val abbreviation = nameMatrix.getAbbreviation(fullName)
-            if (abbreviation.isNullOrEmpty()) {
-                println("WARNING Device name was not abbreviated: $fullName")
-                continue
-            }
-            addToCache(abbreviation, device)
+            if (abbreviation.isSuccess) addToCache(abbreviation.getOrThrow(), device)
+            else println("WARNING Device name was not abbreviated: $fullName")
         }
     }
 
@@ -92,10 +89,9 @@ class DeviceAbbreviator {
         }
     }
 
-    fun getAbbreviation(fullName: String): String? {
-        if (fullName !in this.names) return null
-        val i = this.names[fullName] ?: return null
-        return this.abbreviations[i]
+    fun getAbbreviation(fullName: String): Result<String> {
+        val i = this.names[fullName] ?: return Result.failure(IllegalArgumentException("$fullName was never abbreviated"))
+        return Result.success(this.abbreviations[i])
     }
 
     private fun appendNextTokensToAbbreviations(): Boolean {

--- a/src/main/kotlin/DeviceManager.kt
+++ b/src/main/kotlin/DeviceManager.kt
@@ -68,7 +68,6 @@ class DeviceAbbreviator {
     private val names: MutableMap<String, Int> = mutableMapOf()
     private val abbreviations: MutableList<String> = mutableListOf()
     private val previousAbbreviationLength: MutableList<Int> = mutableListOf()
-    private var width: Int = 0
 
     fun addName(name: String) {
         if (name in this.names) {
@@ -79,7 +78,6 @@ class DeviceAbbreviator {
         this.tokenizedNames.add(tokenizedName)
         this.abbreviations.add("")
         this.previousAbbreviationLength.add(0)
-        this.width = maxOf(this.width, tokenizedNames.size)
     }
 
     fun abbreviateMatrix() {

--- a/src/test/kotlin/DeviceManagerTest.kt
+++ b/src/test/kotlin/DeviceManagerTest.kt
@@ -18,7 +18,9 @@ class DeviceManagerTest {
                 {"id": 3, "label": "Bedroom Light", "type": "Room Lights Activator Switch"},
                 {"id": 4, "label": "Garage Door", "type": "Virtual Switch"},
                 {"id": 5, "label": "Baruch Office Light", "type": "Room Lights Activator Shade"},
-                {"id": 6, "label": "Master Bedroom Shades", "type": "Room Lights Activator Shade"}
+                {"id": 6, "label": "Master Bedroom Shades", "type": "Room Lights Activator Shade"},
+                {"id": 7, "label": "Master Bedroom Lights", "type": "Room Lights Activator Switch"},
+                {"id": 8, "label": "Master Bathroom Lights", "type": "Room Lights Activator Switch"}
             ]
         """.trimIndent()
 
@@ -85,5 +87,19 @@ class DeviceManagerTest {
         val result = deviceManager.findDevice("Master Bedroom Shades", "on")
         assertTrue(result.isFailure)
         assertEquals("Command 'on' is not supported by device 'Master Bedroom Shades'", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `test conflicting abbreviation does not exist`() {
+        val result = deviceManager.findDevice("mbl", "on")
+        assertTrue(result.isFailure)
+        assertEquals("No device found for query: mbl", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `test finding shortest possible abbreviation`() {
+        val result = deviceManager.findDevice("mbel", "on")
+        assertTrue(result.isSuccess)
+        assertEquals(7, result.getOrNull()?.id)
     }
 }


### PR DESCRIPTION
Add disambiguation logic to find the shortest possible abbreviation when the initials of each device match.

**Example:** Given two devices `Master Bedroom Lights` and `Master Bathroom Lights` the current behavior is to abbreviate both of the devices as `mbl`, which would result in a collision. Now, the device names will be shortened to `mbel` and `mbal` since the third character in each abbreviation is the first character that differs between the two names.

The earliest difference is prioritized. This means that if we have `Main Bedroom Light` and `Master Bathroom Lights` the abbreviations will be `maibl` and `masbl`.

For the sake of completeness of the example, if we have `Master Bedroom Lights`, `Master Bathroom Lights`, and `Main Bedroom Light` the created abbreviations will be `masbel`, `masbal`, and `maibl`.