### PR TITLE
Fix Zooz ZEN Plugs Advanced serialization crash + restore coverage gate

### DIFF
--- a/.kiro/specs/hub-update-error-handling/REAL_FIX_SUMMARY.md
+++ b/.kiro/specs/hub-update-error-handling/REAL_FIX_SUMMARY.md
@@ -88,7 +88,7 @@ docker run -d --name tg-hubitat-bot \
   -e BOT_TOKEN=your_token \
   -e MAKER_API_APP_ID=398 \
   -e MAKER_API_TOKEN=your_token \
-  -e DEFAULT_HUB_IP=192.168.30.2 \
+  -e DEFAULT_HUB_IP=192.168.30.15 \
   jbaru.ch/tg-hubitat-bot:3.2
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "jbaru.ch"
-version = "3.3"
+version = "3.4"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/model/Device.kt
+++ b/src/main/kotlin/model/Device.kt
@@ -100,6 +100,10 @@ sealed class Device {
     data class ZoozZenSwitchAdvanced(override val id: Int, override val label: String) : Actuator()
 
     @Serializable
+    @SerialName("Zooz ZEN Plugs Advanced")
+    data class ZoozZenPlugsAdvanced(override val id: Int, override val label: String) : Actuator()
+
+    @Serializable
     @SerialName("Room Lights Activator Shade")
     data class RoomLightsActivatorShade(override val id: Int, override val label: String) : Shade()
 }

--- a/src/test/kotlin/HubOperationsTest.kt
+++ b/src/test/kotlin/HubOperationsTest.kt
@@ -250,11 +250,27 @@ class HubOperationsTest : FunSpec({
                 HubOperations.getHubVersions(hub, networkClient, hubIp, makerApiAppId, makerApiToken)
                 throw AssertionError("Expected exception to be thrown")
             } catch (e: Exception) {
-                e.message shouldContain "Test Hub"
-                e.message shouldContain "http://hubitat.local/apps/api/test-app-id/devices/1"
+                e.message shouldContain "empty response"
             }
         }
         
+        test("should handle incomplete/truncated response") {
+            val hub = Device.Hub(1, "Test Hub")
+            
+            // Simulate truncated JSON response (like just ")")
+            whenever(networkClient.getBody(eq("http://hubitat.local/apps/api/test-app-id/devices/1"), any()))
+                .thenReturn(")")
+            
+            try {
+                HubOperations.getHubVersions(hub, networkClient, hubIp, makerApiAppId, makerApiToken)
+                throw AssertionError("Expected exception to be thrown")
+            } catch (e: Exception) {
+                e.message shouldContain "incomplete response"
+                e.message shouldContain "1 chars"
+                e.message shouldContain ")"
+            }
+        }
+
         test("should truncate long response preview to 200 characters") {
             val hub = Device.Hub(1, "Test Hub")
             

--- a/src/test/kotlin/HubOperationsTest.kt
+++ b/src/test/kotlin/HubOperationsTest.kt
@@ -208,7 +208,22 @@ class HubOperationsTest : FunSpec({
             current shouldBe ""
             available shouldBe ""
         }
-        
+
+        test("should handle response with no attributes key at all") {
+            val hub = Device.Hub(1, "Test Hub")
+
+            // Valid JSON, long enough to pass the length check, but no "attributes" array
+            val makerApiResponse = """{"id": "1", "name": "Hub Information"}"""
+
+            whenever(networkClient.getBody(eq("http://hubitat.local/apps/api/test-app-id/devices/1"), any()))
+                .thenReturn(makerApiResponse)
+
+            val (current, available) = HubOperations.getHubVersions(hub, networkClient, hubIp, makerApiAppId, makerApiToken)
+
+            current shouldBe ""
+            available shouldBe ""
+        }
+
         test("should handle network error") {
             val hub = Device.Hub(1, "Test Hub")
             
@@ -376,7 +391,7 @@ class HubOperationsTest : FunSpec({
             val hub1 = Device.Hub(1, "Hub 1")
             hub1.ip = "192.168.1.100"
             hub1.managementToken = "token1"
-            
+
             val makerApiResponse = """
                 {
                     "attributes": [
@@ -385,16 +400,16 @@ class HubOperationsTest : FunSpec({
                     ]
                 }
             """.trimIndent()
-            
+
             val mockResponse: HttpResponse = mock()
             whenever(mockResponse.status).thenReturn(HttpStatusCode.OK)
-            
+
             whenever(networkClient.getBody(eq("http://hubitat.local/apps/api/test-app-id/devices/1"), any()))
                 .thenReturn(makerApiResponse)
-            
+
             whenever(networkClient.get(argThat { contains("/management/firmwareUpdate") }, any()))
                 .thenReturn(mockResponse)
-            
+
             val messages = mutableListOf<String>()
             val result = HubOperations.updateHubsWithPolling(
                 listOf(hub1),
@@ -405,10 +420,79 @@ class HubOperationsTest : FunSpec({
                 maxAttempts = 2,
                 delayMillis = 100
             ) { messages.add(it) }
-            
+
             result.isFailure shouldBe true
             result.exceptionOrNull()?.message shouldContain "Update timeout"
             messages.any { it.contains("Timeout") } shouldBe true
+        }
+
+        test("should fail when update initiation returns non-OK status") {
+            val hub1 = Device.Hub(1, "Hub 1")
+            hub1.ip = "192.168.1.100"
+            hub1.managementToken = "token1"
+
+            val needsUpdateResponse = """
+                {
+                    "attributes": [
+                        {"name": "firmwareVersionString", "currentValue": "2.3.4.150"},
+                        {"name": "hubUpdateVersion", "currentValue": "2.3.5.160"}
+                    ]
+                }
+            """.trimIndent()
+
+            val mockResponse: HttpResponse = mock()
+            whenever(mockResponse.status).thenReturn(HttpStatusCode.InternalServerError)
+
+            whenever(networkClient.getBody(eq("http://hubitat.local/apps/api/test-app-id/devices/1"), any()))
+                .thenReturn(needsUpdateResponse)
+            whenever(networkClient.get(argThat { contains("/management/firmwareUpdate") }, any()))
+                .thenReturn(mockResponse)
+
+            val result = HubOperations.updateHubsWithPolling(
+                listOf(hub1),
+                networkClient,
+                hubIp,
+                makerApiAppId,
+                makerApiToken,
+                maxAttempts = 2,
+                delayMillis = 100
+            ) { }
+
+            result.isFailure shouldBe true
+            result.exceptionOrNull()?.message shouldContain "Failed to initiate update for hub Hub 1"
+        }
+
+        test("should fail when update initiation throws an exception") {
+            val hub1 = Device.Hub(1, "Hub 1")
+            hub1.ip = "192.168.1.100"
+            hub1.managementToken = "token1"
+
+            val needsUpdateResponse = """
+                {
+                    "attributes": [
+                        {"name": "firmwareVersionString", "currentValue": "2.3.4.150"},
+                        {"name": "hubUpdateVersion", "currentValue": "2.3.5.160"}
+                    ]
+                }
+            """.trimIndent()
+
+            whenever(networkClient.getBody(eq("http://hubitat.local/apps/api/test-app-id/devices/1"), any()))
+                .thenReturn(needsUpdateResponse)
+            whenever(networkClient.get(argThat { contains("/management/firmwareUpdate") }, any()))
+                .thenThrow(RuntimeException("connection refused"))
+
+            val result = HubOperations.updateHubsWithPolling(
+                listOf(hub1),
+                networkClient,
+                hubIp,
+                makerApiAppId,
+                makerApiToken,
+                maxAttempts = 2,
+                delayMillis = 100
+            ) { }
+
+            result.isFailure shouldBe true
+            result.exceptionOrNull()?.message shouldContain "connection refused"
         }
         
         test("should report progress messages") {


### PR DESCRIPTION
## Why

The bot was crashing at boot on the NAS and staying down. Root cause: a newly-added device, `Zooz ZEN Plugs Advanced` ("Backyard String Lights"), had no registered `@Serializable` subclass in the sealed `Device` hierarchy. `kotlinx.serialization` uses `type` as the polymorphic discriminator, so one unknown device type throws during `DeviceManager.refreshDevices` and takes the whole process down.

While fixing that, main's CI turned out to be **already red**: the prior hub empty/incomplete-response commits (`d7a9870`, `78dbb9a`) added error branches to `HubOperations` but dropped BRANCH coverage to 0.686, under the 0.70 gate. A half-finished test edit was also left in the tree, breaking compilation.

## What

- **Register `Zooz ZEN Plugs Advanced`** as an `Actuator` subclass (smart plug, on/off).
- **Remove an orphaned assertion block** in `HubOperationsTest` left behind by a botched merge (broke compilation).
- **Add tests** for the uncovered `HubOperations` error branches (no-attributes-key parse path; update-initiation non-OK status and thrown-exception paths), clearing the 0.70 coverage gate.
- Correct a stale default-hub-IP doc example (`.2` → `.15`).
- Bump version `3.3` → `3.4`.

## Verification

- `./gradlew build` green locally (tests + coverage gate pass).
- Deployed `3.4` to the NAS; container now logs `Init successful, 65 devices loaded, start polling` (previously the crash point) and is polling Telegram normally.

## Note

A single unknown device type still crashes the entire bot at boot. Worth a follow-up to skip/log unknown types instead — happy to do it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3u23Papja4YbdH1xeQNUx