### PR TITLE
Fix hub-update watcher declaring false failures on reboot

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "jbaru.ch"
-version = "3.4"
+version = "3.5"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/HubOperations.kt
+++ b/src/main/kotlin/HubOperations.kt
@@ -196,65 +196,51 @@ object HubOperations {
             }
         }
         
-        // Poll hub versions periodically
+        // Poll hub versions periodically.
+        //
+        // A hub is done when its firmware moves off the original version. While a
+        // hub reboots to apply the update, the Maker API returns empty/error
+        // responses and getHubVersions throws - that is EXPECTED mid-update
+        // progress, NOT a failure. Treat it as "still rebooting", keep the hub
+        // in-progress, and keep polling until it reports the new version. A hub
+        // that genuinely never completes surfaces as the timeout below; it is
+        // never declared failed mid-flight on a transient reboot blip (which used
+        // to end the whole watch early and mis-report a successful update).
         var currentProgress = updateProgress
         var attempts = 0
-        
+
         while (!currentProgress.isComplete && attempts < maxAttempts) {
             delay(delayMillis)
             attempts++
-            
+
             val updatedHubs = mutableSetOf<String>()
-            val failedHubs = mutableMapOf<String, String>()
-            
+
             for (hubLabel in currentProgress.inProgressHubs) {
                 val hub = hubs.find { it.label == hubLabel } ?: continue
                 try {
-                    // Retry logic for transient failures (empty responses, network issues)
-                    var retryCount = 0
-                    val maxRetries = 3
-                    var lastException: Exception? = null
-                    
-                    while (retryCount < maxRetries) {
-                        try {
-                            val (newCurrent, _) = getHubVersions(hub, networkClient, hubIp, makerApiAppId, makerApiToken)
-                            val originalVersion = versionInfo[hubLabel]!!.currentVersion
-                            val targetVersion = versionInfo[hubLabel]!!.availableVersion
-                            
-                            if (newCurrent != originalVersion) {
-                                updatedHubs.add(hubLabel)
-                                progressCallback("Hub $hubLabel updated from $originalVersion to $newCurrent")
-                            }
-                            break  // Success, exit retry loop
-                        } catch (e: Exception) {
-                            lastException = e
-                            retryCount++
-                            if (retryCount < maxRetries) {
-                                // Exponential backoff: 2s, 4s, 8s
-                                val backoffDelay = 2000L * (1 shl (retryCount - 1))
-                                delay(backoffDelay)
-                            }
-                        }
+                    val (newCurrent, _) = getHubVersions(hub, networkClient, hubIp, makerApiAppId, makerApiToken)
+                    val originalVersion = versionInfo[hubLabel]!!.currentVersion
+                    if (newCurrent != originalVersion) {
+                        updatedHubs.add(hubLabel)
+                        progressCallback("Hub $hubLabel updated from $originalVersion to $newCurrent")
                     }
-                    
-                    // If all retries failed, mark as failed
-                    if (retryCount >= maxRetries && lastException != null) {
-                        throw lastException
-                    }
-                } catch (e: Exception) {
-                    failedHubs[hubLabel] = e.message ?: "Unknown error"
+                    // else: still on the old version - update still in progress, keep polling
+                } catch (_: Exception) {
+                    // Hub unreachable / empty response: it is rebooting to apply the
+                    // update. Keep waiting; do not mark it failed.
+                    progressCallback("Hub $hubLabel is applying the update (not reachable yet); still waiting")
                 }
             }
-            
+
             currentProgress = UpdateProgress(
                 totalHubs = currentProgress.totalHubs,
                 updatedHubs = currentProgress.updatedHubs + updatedHubs,
-                failedHubs = currentProgress.failedHubs + failedHubs,
-                inProgressHubs = currentProgress.inProgressHubs - updatedHubs - failedHubs.keys
+                failedHubs = currentProgress.failedHubs,
+                inProgressHubs = currentProgress.inProgressHubs - updatedHubs
             )
-            
+
             if (!currentProgress.isComplete) {
-                progressCallback("Progress: ${currentProgress.successCount}/${currentProgress.totalHubs} updated, ${currentProgress.failureCount} failed, ${currentProgress.inProgressHubs.size} in progress")
+                progressCallback("Progress: ${currentProgress.successCount}/${currentProgress.totalHubs} updated, ${currentProgress.inProgressHubs.size} still updating")
             }
         }
         

--- a/src/test/kotlin/HubOperationsTest.kt
+++ b/src/test/kotlin/HubOperationsTest.kt
@@ -494,7 +494,60 @@ class HubOperationsTest : FunSpec({
             result.isFailure shouldBe true
             result.exceptionOrNull()?.message shouldContain "connection refused"
         }
-        
+
+        test("should keep polling through a reboot (empty response) and report success") {
+            // Regression: a hub returns an empty response while rebooting to apply
+            // the update. That must be treated as still-in-progress, not a failure
+            // that ends the watch early and mis-reports a successful update.
+            val hub1 = Device.Hub(1, "Hub 1")
+            hub1.ip = "192.168.1.100"
+            hub1.managementToken = "token1"
+
+            val beforeUpdateResponse = """
+                {
+                    "attributes": [
+                        {"name": "firmwareVersionString", "currentValue": "2.3.4.150"},
+                        {"name": "hubUpdateVersion", "currentValue": "2.3.5.160"}
+                    ]
+                }
+            """.trimIndent()
+
+            val afterUpdateResponse = """
+                {
+                    "attributes": [
+                        {"name": "firmwareVersionString", "currentValue": "2.3.5.160"},
+                        {"name": "hubUpdateVersion", "currentValue": "2.3.5.160"}
+                    ]
+                }
+            """.trimIndent()
+
+            val mockResponse: HttpResponse = mock()
+            whenever(mockResponse.status).thenReturn(HttpStatusCode.OK)
+
+            // init: needs update; poll 1: empty (rebooting -> throws); poll 2: updated
+            whenever(networkClient.getBody(eq("http://hubitat.local/apps/api/test-app-id/devices/1"), any()))
+                .thenReturn(beforeUpdateResponse)
+                .thenReturn("")
+                .thenReturn(afterUpdateResponse)
+            whenever(networkClient.get(argThat { contains("/management/firmwareUpdate") }, any()))
+                .thenReturn(mockResponse)
+
+            val messages = mutableListOf<String>()
+            val result = HubOperations.updateHubsWithPolling(
+                listOf(hub1),
+                networkClient,
+                hubIp,
+                makerApiAppId,
+                makerApiToken,
+                maxAttempts = 5,
+                delayMillis = 100
+            ) { messages.add(it) }
+
+            result.isSuccess shouldBe true
+            result.getOrNull() shouldContain "Successfully updated"
+            messages.any { it.contains("still waiting") } shouldBe true
+        }
+
         test("should report progress messages") {
             val hub1 = Device.Hub(1, "Hub 1")
             hub1.ip = "192.168.1.100"


### PR DESCRIPTION
## Symptom

Caught live: a `/update` on 3 hubs reported **"Failed to update 3 hubs"** ~100 seconds in, then all hubs finished updating successfully (two confirmed on 2.5.1.131 afterward). The watcher times out too soon, declares failure, and the updates finish fine — exactly as reported.

## Root cause

In `updateHubsWithPolling`'s polling loop:

1. When a hub reboots to apply firmware, the Maker API returns an **empty response** and `getHubVersions` throws.
2. The in-poll retry (3× with ~14s backoff) can't outlast a multi-minute reboot, so it exhausts and rethrows.
3. The catch marked the hub `failedHubs[label] = "empty response"` — but an empty response mid-update means *rebooting*, not *failed*.
4. Once a hub lands in `failedHubs`, `isComplete` (`updated + failed == total`) flips true and the `while` loop **exits immediately** — never using the polling window. It bailed at ~2 min and mis-reported a successful update.

## Fix

Treat an empty/error response during polling as **expected mid-update progress**: keep the hub in-progress and keep polling until it reports the new firmware version. A hub is "done" only when its firmware moves off the original version. Genuine non-completion surfaces via the existing timeout after `maxAttempts`; a hub is never declared failed mid-flight on a transient reboot blip. Removed the useless in-poll retry loop.

## Tests

- New regression test: empty response mid-poll → keeps polling → reports success.
- Existing timeout/success/progress tests still pass; coverage gate green.

## Verified

Built 3.5, deployed to the NAS, boots clean (`Init successful, 65 devices loaded, start polling`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3u23Papja4YbdH1xeQNUx