### PR TITLE
Resilience: unknown/new device types no longer crash the bot at boot + tessl cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,19 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### tessl ###
+# tessl.json is the descriptor and IS committed; everything below is
+# downloaded plugin content or generated agent/MCP config that `tessl install`
+# regenerates from tessl.json (npm model: commit the manifest, ignore node_modules).
+.tessl/
+.mcp.json
+.agents/
+.claude/
+.codex/
+.gemini/
+.github/mcp.json
+.github/skills/
+AGENTS.md
+CLAUDE.md
+package-lock.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "jbaru.ch"
-version = "3.5"
+version = "3.6"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/DeviceManager.kt
+++ b/src/main/kotlin/DeviceManager.kt
@@ -2,6 +2,10 @@ package jbaru.ch.telegram.hubitat
 
 import jbaru.ch.telegram.hubitat.model.Device
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 class DeviceManager(deviceListJson: String) {
 
@@ -17,10 +21,29 @@ class DeviceManager(deviceListJson: String) {
 
     fun refreshDevices(deviceListJson: String): Pair<Int, List<String>> {
         val format = Json { ignoreUnknownKeys = true }
-        devices = format.decodeFromString<List<Device>>(deviceListJson)
+        val warnings: MutableList<String> = ArrayList()
+
+        // Decode device-by-device so a single unknown or malformed device (e.g. a
+        // newly-installed driver with no @Serializable subclass yet) is skipped
+        // with a visible warning instead of aborting the whole list and crashing
+        // the bot at boot.
+        devices = format.parseToJsonElement(deviceListJson).jsonArray.mapNotNull { element ->
+            try {
+                format.decodeFromJsonElement<Device>(element)
+            } catch (e: Exception) {
+                val type = element.jsonObject["type"]?.jsonPrimitive?.content ?: "unknown"
+                val label = element.jsonObject["label"]?.jsonPrimitive?.content ?: "unknown"
+                val message = "WARNING Skipping unsupported device (type='$type', label='$label'): " +
+                    (e.message?.substringBefore('\n') ?: e.toString())
+                warnings.add(message)
+                println(message)
+                null
+            }
+        }
+
         deviceCache.clear()
-        val result: Pair<Int, List<String>> = Pair(devices.size, initializeCache(devices))
-        return result
+        warnings.addAll(initializeCache(devices))
+        return Pair(devices.size, warnings)
     }
 
     fun isDeviceCommand(command: String): Boolean {

--- a/src/test/kotlin/CommandHandlersTest.kt
+++ b/src/test/kotlin/CommandHandlersTest.kt
@@ -98,13 +98,49 @@ class CommandHandlersTest : FunSpec({
             val device = Device.VirtualSwitch(1, "Kitchen Light")
             whenever(deviceManager.findDevice(eq("kitchen_light"), eq("invalidCommand")))
                 .thenReturn(Result.success(device))
-            
+
             val result = CommandHandlers.handleDeviceCommand(
                 bot, message, deviceManager, networkClient,
                 makerApiAppId, makerApiToken, defaultHubIp
             )
-            
+
             result shouldContain "not supported by device"
+        }
+
+        test("should return error when message text is null") {
+            val message = mock<Message> {
+                on { text } doReturn null
+            }
+
+            val result = CommandHandlers.handleDeviceCommand(
+                bot, message, deviceManager, networkClient,
+                makerApiAppId, makerApiToken, defaultHubIp
+            )
+
+            result shouldContain "Please specify a device name"
+        }
+
+        test("should execute command that takes arguments") {
+            // Covers the args-present path in runDeviceCommand.
+            val message = mock<Message> {
+                on { text } doReturn "/push button 1"
+            }
+            val device = Device.VirtualButton(1, "Button")
+            whenever(deviceManager.findDevice(eq("button"), eq("push")))
+                .thenReturn(Result.success(device))
+
+            val mockResponse = mock<HttpResponse> {
+                on { status } doReturn HttpStatusCode.OK
+            }
+            whenever(networkClient.get(argThat { contains("/devices/1/push/1") }, any()))
+                .thenReturn(mockResponse)
+
+            val result = CommandHandlers.handleDeviceCommand(
+                bot, message, deviceManager, networkClient,
+                makerApiAppId, makerApiToken, defaultHubIp
+            )
+
+            result shouldBe "OK"
         }
     }
     
@@ -224,7 +260,24 @@ class CommandHandlersTest : FunSpec({
                 deviceManager, networkClient,
                 makerApiAppId, makerApiToken, defaultHubIp
             )
-            
+
+            result shouldBe "No open sensors found."
+        }
+
+        test("should treat a sensor with no value attribute as not open") {
+            // Covers the '?: \"Unknown\"' fallback in getDeviceAttribute.
+            val sensor = Device.GenericZigbeeContactSensor(1, "Front Door")
+            whenever(deviceManager.findDevicesByType(Device.ContactSensor::class.java))
+                .thenReturn(listOf(sensor))
+
+            whenever(networkClient.getBody(any(), any()))
+                .thenReturn("""{"notValue": "whatever"}""")
+
+            val result = CommandHandlers.handleGetOpenSensorsCommand(
+                deviceManager, networkClient,
+                makerApiAppId, makerApiToken, defaultHubIp
+            )
+
             result shouldBe "No open sensors found."
         }
     }

--- a/src/test/kotlin/DeviceManagerTest.kt
+++ b/src/test/kotlin/DeviceManagerTest.kt
@@ -118,4 +118,46 @@ class DeviceManagerTest {
         assertEquals(1, switches.size)
         assertEquals("Garage Door", switches.first().label)
     }
+
+    @Test
+    fun `test unknown device type is skipped with a warning instead of crashing`() {
+        // A newly-installed driver with no @Serializable subclass must not take
+        // the whole device list (and the bot) down at boot.
+        val json = """
+            [
+                {"id": 1, "label": "Living Room Lights", "type": "Room Lights Activator Bulb"},
+                {"id": 612, "label": "Backyard String Lights", "type": "Some Brand New Driver"},
+                {"id": 4, "label": "Garage Door", "type": "Virtual Switch"}
+            ]
+        """.trimIndent()
+
+        val manager = DeviceManager(json)
+        val (count, warnings) = manager.refreshDevices(json)
+
+        // The two known devices load; the unknown one is skipped, not fatal.
+        assertEquals(2, count)
+        assertTrue(warnings.any { it.contains("Some Brand New Driver") && it.contains("Backyard String Lights") })
+
+        // Known devices remain usable.
+        assertTrue(manager.findDevice("Living Room Lights", "on").isSuccess)
+        assertTrue(manager.findDevice("Garage Door", "on").isSuccess)
+        // The unknown device is absent.
+        assertTrue(manager.findDevice("Backyard String Lights", "on").isFailure)
+    }
+
+    @Test
+    fun `test malformed device element is skipped with a warning`() {
+        // A structurally-broken entry (missing required fields) is skipped too.
+        val json = """
+            [
+                {"id": 4, "label": "Garage Door", "type": "Virtual Switch"},
+                {"type": "Virtual Switch"}
+            ]
+        """.trimIndent()
+
+        val (count, warnings) = DeviceManager(json).refreshDevices(json)
+
+        assertEquals(1, count)
+        assertTrue(warnings.any { it.startsWith("WARNING Skipping unsupported device") })
+    }
 }

--- a/src/test/kotlin/ModeCommandHandlersTest.kt
+++ b/src/test/kotlin/ModeCommandHandlersTest.kt
@@ -147,6 +147,34 @@ class ModeCommandHandlersTest : FunSpec({
             result shouldContain "Away"
         }
         
+        test("should return error when message text is null") {
+            val message = mock<Message> {
+                on { text } doReturn null
+            }
+
+            val result = CommandHandlers.handleSetModeCommand(
+                message, networkClient, makerApiAppId, makerApiToken, hubIp
+            )
+
+            result shouldContain "Please specify a mode name"
+        }
+
+        test("should return generic error when set mode fails for a non-not-found reason") {
+            // Covers the else branch of the 'Mode not found' check.
+            val message = mock<Message> {
+                on { text } doReturn "/set_mode Away"
+            }
+
+            whenever(networkClient.getBody(any(), any())).thenThrow(RuntimeException("Network boom"))
+
+            val result = CommandHandlers.handleSetModeCommand(
+                message, networkClient, makerApiAppId, makerApiToken, hubIp
+            )
+
+            result shouldContain "Error setting mode"
+            result shouldContain "Network boom"
+        }
+
         test("should format confirmation message correctly") {
             val message = mock<Message> {
                 on { text } doReturn "/set_mode Night"

--- a/tessl.json
+++ b/tessl.json
@@ -1,0 +1,9 @@
+{
+  "name": "tg-hubitat-bot",
+  "mode": "vendored",
+  "dependencies": {
+    "jbaruch/hubitat-dev": {
+      "version": "0.1.18"
+    }
+  }
+}


### PR DESCRIPTION
Two things: make device loading resilient to unknown device types, and clean up the tessl-generated files.

## Resilience (the important one)

`DeviceManager.refreshDevices` decoded the entire device list in one `decodeFromString<List<Device>>` call. Because `Device` is a sealed hierarchy keyed on `type`, a **single** device whose type has no `@Serializable` subclass — i.e. any newly-installed Hubitat driver — threw and crashed the bot at boot. That's exactly what `Zooz ZEN Plugs Advanced` did (PR #7); it would happen again for the next new driver.

Now it decodes **device-by-device**: an unknown or structurally-malformed device is skipped with a visible `WARNING` (type + label + reason, returned in the warnings list and logged), while every device the bot understands still loads. Adding a new driver can no longer take the bot offline — worst case it's absent from the bot with a logged warning until a subclass is added.

Tests: unknown type skipped (known devices still usable), malformed element skipped. Coverage gate green.

## Cleanup

Per "descriptors committed, generated/downloaded ignored":
- **Committed**: `tessl.json` (the descriptor — pins `jbaruch/hubitat-dev@0.1.18`).
- **Gitignored**: `.tessl/plugins` (downloaded plugin), generated MCP/agent configs (`.mcp.json`, `.claude`, `.codex`, `.gemini`, `.agents`, `.github/mcp.json`), downloaded skill copies (`.github/skills`), generated pointers (`AGENTS.md`, `CLAUDE.md`), stray `package-lock.json`. `tessl install` regenerates all of it.

Also cleaned build tars locally and removed the broken `3.3` / superseded `3.4` images from the NAS.

## Verified

Built **3.6**, deployed to the NAS, boots clean (`Init successful, 65 devices loaded, start polling`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3u23Papja4YbdH1xeQNUx