### PR TITLE
Update vulnerable dependencies (clears 11 Dependabot alerts)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,19 @@
+buildscript {
+    configurations.classpath {
+        resolutionStrategy {
+            // The jib-gradle-plugin bundles vulnerable build-time deps
+            // (jackson 2.15.2, commons-lang3 3.14.0). These run only during image
+            // build and never ship in the container, but force patched versions
+            // to clear the Dependabot alerts against the plugin classpath.
+            force(
+                "com.fasterxml.jackson.core:jackson-databind:2.18.9",
+                "com.fasterxml.jackson.core:jackson-core:2.18.9",
+                "org.apache.commons:commons-lang3:3.18.0"
+            )
+        }
+    }
+}
+
 plugins {
     kotlin("jvm") version "2.3.0-RC3"
     kotlin("plugin.serialization") version "2.3.0-RC3"
@@ -7,7 +23,7 @@ plugins {
 }
 
 group = "jbaru.ch"
-version = "3.6"
+version = "3.7"
 
 repositories {
     mavenCentral()
@@ -22,6 +38,15 @@ val kotlinx_serialization_version: String by project
 val kotest_version: String by project
 
 dependencies {
+    constraints {
+        // gson is pulled transitively by the telegram bot (retrofit converter-gson)
+        // at 2.8.5, which has a known deserialization DoS (CVE fixed in 2.8.9).
+        // Force a patched version onto the runtime classpath.
+        implementation("com.google.code.gson:gson:2.11.0") {
+            because("2.8.5 (pulled via retrofit converter-gson) is vulnerable; 2.8.9+ is patched")
+        }
+    }
+
     implementation("io.github.kotlin-telegram-bot.kotlin-telegram-bot:telegram:$kotlin_tg_bot_version")
     testImplementation(kotlin("test"))
     implementation("io.ktor:ktor-client-core:$ktor_version")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 ktor_version=3.2.0
-logback_version=1.5.18
+logback_version=1.5.34
 kotlin_tg_bot_version=6.3.0
 kotlinx_serialization_version=1.9.0
 kotest_version=5.9.1


### PR DESCRIPTION
Dependabot flagged 11 vulnerabilities (3 high, 5 moderate, 3 low) but could not open PRs for them — they're all **transitive**, with no direct declaration to bump, so its update runs failed and no PRs appeared.

Fixed manually, split by where they actually live:

## Runtime (ships in the container)
- **logback** `1.5.18 → 1.5.34` (direct via `logback_version`) — fixes the logback-core alerts.
- **gson** forced `2.8.5 → 2.11.0` via a dependency constraint — pulled transitively through the telegram bot's retrofit `converter-gson`; 2.8.5 has a deserialization DoS (high).

## Build-time only (jib plugin classpath — never in the image)
- **jackson-databind/core** `2.15.2 → 2.18.9` and **commons-lang3** `3.14.0 → 3.18.0`, forced on the buildscript classpath. These run only during image build; the container never contains them.

## Verified
- `runtimeClasspath` now resolves gson 2.11.0 and logback 1.5.34; jackson/commons-lang3 are absent from all app classpaths (build-time only).
- `./gradlew clean build` green (tests + coverage gate); jib image builds fine with the bumped jackson.
- Built **3.7**, deployed to the NAS, boots clean (`Init successful, 65 devices loaded, start polling`).

Note: there's no `.github/dependabot.yml` — security updates are on by default but can't bump transitives. Happy to add a dependabot config for regular version-update PRs on direct deps if you want ongoing coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3u23Papja4YbdH1xeQNUx