### PR TITLE
Robustness: redact log credentials, harden hub init, HTTP timeouts, declarative deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copy to .env (which is gitignored) and fill in real values.
+# Consumed by docker-compose.yml for variable substitution.
+
+# Telegram bot token from @BotFather
+BOT_TOKEN=
+# Maker API app id and token (from the Maker API app on the primary hub)
+MAKER_API_APP_ID=
+MAKER_API_TOKEN=
+# Optional: chat id to send the startup message to
+CHAT_ID=
+# IP (or hostname) of the primary hub the Maker API app is installed on
+DEFAULT_HUB_IP=hubitat.local
+# Image tag to run; deploy.sh sets this to the build version
+TAG=latest

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ bin/
 AGENTS.md
 CLAUDE.md
 package-lock.json
+
+### Deploy secrets ###
+# Real secrets live here; .env.example is the committed descriptor.
+.env

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "jbaru.ch"
-version = "3.7"
+version = "3.8"
 
 repositories {
     mavenCentral()

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Build the image tar, ship it to the NAS, load it, and (re)start via docker compose.
+#
+# Prereqs (one-time on the NAS, in $NAS_DIR):
+#   - docker-compose.yml (this script ships it each run)
+#   - .env with the real secrets (see .env.example; never committed, stays on the NAS)
+#
+# Usage: ./deploy.sh          (host/dir overridable via NAS_HOST / NAS_DIR env vars)
+set -euo pipefail
+
+NAS_HOST="${NAS_HOST:-nas}"
+NAS_DIR="${NAS_DIR:-/home/jbaruch/hubitat-bot}"
+
+VERSION="$(grep -E '^version\s*=' build.gradle.kts | sed -E 's/.*"([^"]+)".*/\1/')"
+if [ -z "$VERSION" ]; then
+  echo "Could not read version from build.gradle.kts" >&2
+  exit 1
+fi
+
+echo "==> Building tg-hubitat-bot ${VERSION}"
+./gradlew --no-daemon jibBuildTar
+
+TAR="build/tg-hubitat-bot-${VERSION}-docker-image.tar"
+if [ ! -f "$TAR" ]; then
+  echo "Image tar not found: $TAR" >&2
+  exit 1
+fi
+
+echo "==> Shipping image and compose file to ${NAS_HOST}:${NAS_DIR}"
+ssh "$NAS_HOST" "mkdir -p '${NAS_DIR}'"
+scp -O "$TAR" "${NAS_HOST}:${NAS_DIR}/image.tar"
+scp -O docker-compose.yml "${NAS_HOST}:${NAS_DIR}/docker-compose.yml"
+
+echo "==> Loading image and starting via compose on ${NAS_HOST}"
+ssh "$NAS_HOST" "cd '${NAS_DIR}' && docker load < image.tar && rm -f image.tar && TAG='${VERSION}' docker compose up -d"
+
+echo "==> Deployed ${VERSION}. Recent logs:"
+ssh "$NAS_HOST" "docker logs --tail 8 jbaru.ch_tg-hubitat-bot-1 2>&1 | grep -iE 'Init successful|Exception|Skipping' || docker logs --tail 8 jbaru.ch_tg-hubitat-bot-1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  tg-hubitat-bot:
+    image: jbaru.ch/tg-hubitat-bot:${TAG:-latest}
+    container_name: jbaru.ch_tg-hubitat-bot-1
+    restart: unless-stopped
+    environment:
+      BOT_TOKEN: ${BOT_TOKEN}
+      MAKER_API_APP_ID: ${MAKER_API_APP_ID}
+      MAKER_API_TOKEN: ${MAKER_API_TOKEN}
+      CHAT_ID: ${CHAT_ID:-}
+      DEFAULT_HUB_IP: ${DEFAULT_HUB_IP:-hubitat.local}

--- a/src/main/kotlin/HubOperations.kt
+++ b/src/main/kotlin/HubOperations.kt
@@ -4,7 +4,6 @@ import io.ktor.http.HttpStatusCode
 import jbaru.ch.telegram.hubitat.model.Device
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.coroutines.delay
@@ -41,23 +40,38 @@ object HubOperations {
         makerApiAppId: String,
         makerApiToken: String
     ): List<Device.Hub> {
+        // Initialize each hub independently: a hub that doesn't expose a usable
+        // localIP (or errors out) is skipped with a warning rather than taking the
+        // whole startup down with an NPE. Only fully-initialized hubs are returned,
+        // since a hub without ip/managementToken can't be updated or rebooted.
         val hubs = deviceManager.findDevicesByType(Device.Hub::class.java)
+        val initialized = mutableListOf<Device.Hub>()
         for (hub in hubs) {
-            val json: Map<String, JsonElement> =
-                Json.parseToJsonElement(
+            try {
+                val json = Json.parseToJsonElement(
                     networkClient.getBody(
                         "http://${hubIp}/apps/api/${makerApiAppId}/devices/${hub.id}",
                         mapOf("access_token" to makerApiToken)
                     )
                 ).jsonObject
 
-            val ip = (json["attributes"] as JsonArray).find {
-                it.jsonObject["name"]!!.jsonPrimitive.content == "localIP"
-            }!!.jsonObject["currentValue"]!!.jsonPrimitive.content
-            hub.ip = ip
-            hub.managementToken = networkClient.getBody("http://${ip}/hub/advanced/getManagementToken")
+                val ip = (json["attributes"] as? JsonArray)
+                    ?.firstOrNull { it.jsonObject["name"]?.jsonPrimitive?.content == "localIP" }
+                    ?.jsonObject?.get("currentValue")?.jsonPrimitive?.content
+
+                if (ip.isNullOrBlank()) {
+                    println("WARNING Skipping hub '${hub.label}' (id=${hub.id}): no localIP attribute exposed via Maker API")
+                    continue
+                }
+
+                hub.ip = ip
+                hub.managementToken = networkClient.getBody("http://${ip}/hub/advanced/getManagementToken")
+                initialized.add(hub)
+            } catch (e: Exception) {
+                println("WARNING Skipping hub '${hub.label}' (id=${hub.id}): ${e.message?.substringBefore('\n') ?: e}")
+            }
         }
-        return hubs
+        return initialized
     }
     
     suspend fun getHubVersions(

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -10,6 +10,7 @@ import com.github.kotlintelegrambot.entities.Message
 import io.ktor.client.*
 import io.ktor.client.call.body
 import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.http.HttpStatusCode
@@ -29,7 +30,14 @@ import io.ktor.client.statement.bodyAsText
 
 private lateinit var config: BotConfiguration
 private lateinit var hubs: List<Device.Hub>
-private val client = HttpClient(CIO)
+private val client = HttpClient(CIO) {
+    // Never let a hung or rebooting hub block a command handler forever.
+    install(HttpTimeout) {
+        connectTimeoutMillis = 10_000
+        requestTimeoutMillis = 30_000
+        socketTimeoutMillis = 30_000
+    }
+}
 private lateinit var networkClient: NetworkClient
 private lateinit var deviceManager: DeviceManager
 

--- a/src/main/kotlin/NetworkClient.kt
+++ b/src/main/kotlin/NetworkClient.kt
@@ -17,9 +17,9 @@ interface NetworkClient {
 
 class KtorNetworkClient(private val client: HttpClient) : NetworkClient {
     private val logger = LoggerFactory.getLogger(KtorNetworkClient::class.java)
-    
+
     override suspend fun get(url: String, params: Map<String, String>): HttpResponse {
-        logger.info("HTTP GET: $url with params: $params")
+        logger.info("HTTP GET: $url with params: ${redact(params)}")
         val response = client.get(url) {
             params.forEach { (key, value) ->
                 parameter(key, value)
@@ -28,18 +28,22 @@ class KtorNetworkClient(private val client: HttpClient) : NetworkClient {
         logger.info("HTTP Response: status=${response.status}, content-type=${response.contentType()}")
         return response
     }
-    
+
     override suspend fun getBody(url: String, params: Map<String, String>): String {
-        logger.info("HTTP GET (body): $url with params: $params")
+        logger.info("HTTP GET (body): $url with params: ${redact(params)}")
         val response = get(url, params)
         val body = response.body<String>()
-        val preview = if (body.length > 500) body.take(500) + "..." else body
-        logger.info("HTTP Response body preview (${body.length} chars): $preview")
+        if (isSecretResponse(url)) {
+            logger.info("HTTP Response body (${body.length} chars): [REDACTED]")
+        } else {
+            val preview = if (body.length > 500) body.take(500) + "..." else body
+            logger.info("HTTP Response body preview (${body.length} chars): $preview")
+        }
         return body
     }
-    
+
     override suspend fun put(url: String, params: Map<String, String>): HttpResponse {
-        logger.info("HTTP PUT: $url with params: $params")
+        logger.info("HTTP PUT: $url with params: ${redact(params)}")
         val response = client.put(url) {
             params.forEach { (key, value) ->
                 parameter(key, value)
@@ -47,5 +51,16 @@ class KtorNetworkClient(private val client: HttpClient) : NetworkClient {
         }
         logger.info("HTTP Response: status=${response.status}, content-type=${response.contentType()}")
         return response
+    }
+
+    companion object {
+        // Query params whose values are credentials and must never hit the logs.
+        private val SENSITIVE_KEYS = setOf("access_token", "token")
+
+        internal fun redact(params: Map<String, String>): Map<String, String> =
+            params.mapValues { (key, value) -> if (key in SENSITIVE_KEYS) "[REDACTED]" else value }
+
+        // Endpoints whose response body is itself a secret (the hub management token).
+        internal fun isSecretResponse(url: String): Boolean = url.contains("getManagementToken")
     }
 }

--- a/src/test/kotlin/HubOperationsTest.kt
+++ b/src/test/kotlin/HubOperationsTest.kt
@@ -88,10 +88,33 @@ class HubOperationsTest : FunSpec({
             val result = HubOperations.initializeHubs(
                 deviceManager, networkClient, hubIp, makerApiAppId, makerApiToken
             )
-            
+
             result.size shouldBe 2
             result[0].ip shouldBe "192.168.1.100"
             result[1].ip shouldBe "192.168.1.101"
+        }
+
+        test("should skip a hub with no localIP instead of crashing, keeping the good ones") {
+            val goodHub = Device.Hub(1, "Good Hub")
+            val badHub = Device.Hub(2, "Bad Hub")
+            whenever(deviceManager.findDevicesByType(Device.Hub::class.java))
+                .thenReturn(listOf(goodHub, badHub))
+
+            whenever(networkClient.getBody(argThat { contains("/devices/1") }, any()))
+                .thenReturn("""{"attributes": [{"name": "localIP", "currentValue": "192.168.1.100"}]}""")
+            // Bad hub exposes attributes but no localIP.
+            whenever(networkClient.getBody(argThat { contains("/devices/2") }, any()))
+                .thenReturn("""{"attributes": [{"name": "temperatureScale", "currentValue": "F"}]}""")
+            whenever(networkClient.getBody(argThat { contains("192.168.1.100") }, any()))
+                .thenReturn("token1")
+
+            val result = HubOperations.initializeHubs(
+                deviceManager, networkClient, hubIp, makerApiAppId, makerApiToken
+            )
+
+            // Only the good hub is returned; the bad one is skipped, not fatal.
+            result.map { it.label } shouldBe listOf("Good Hub")
+            result[0].ip shouldBe "192.168.1.100"
         }
     }
     

--- a/src/test/kotlin/NetworkClientTest.kt
+++ b/src/test/kotlin/NetworkClientTest.kt
@@ -51,8 +51,30 @@ class NetworkClientTest : FunSpec({
                 "http://test.com/api",
                 mapOf("access_token" to "token123")
             )
-            
+
             response.status shouldBe HttpStatusCode.OK
+        }
+    }
+
+    context("secret redaction") {
+        test("redact masks sensitive param values but keeps the rest") {
+            val redacted = KtorNetworkClient.redact(
+                mapOf("access_token" to "secret123", "token" to "mgmt456", "mode" to "Away")
+            )
+
+            redacted["access_token"] shouldBe "[REDACTED]"
+            redacted["token"] shouldBe "[REDACTED]"
+            redacted["mode"] shouldBe "Away"
+        }
+
+        test("redact leaves a map with no sensitive keys unchanged") {
+            val params = mapOf("mode" to "Home", "id" to "5")
+            KtorNetworkClient.redact(params) shouldBe params
+        }
+
+        test("isSecretResponse flags the management-token endpoint") {
+            KtorNetworkClient.isSecretResponse("http://192.168.30.15/hub/advanced/getManagementToken") shouldBe true
+            KtorNetworkClient.isSecretResponse("http://192.168.30.15/apps/api/398/devices") shouldBe false
         }
     }
 })


### PR DESCRIPTION
Four improvements from the codebase review, all in the reliability/security theme of this session's work.

## 🔴 Redact credentials from logs
`KtorNetworkClient` logged every request's params (which include `access_token` and hub **management tokens**) and full response bodies — including `/getManagementToken`, whose body *is* the token. Hub credentials were sitting in plaintext in `docker logs`. Now sensitive param values (`access_token`, `token`) are redacted, and secret-endpoint response bodies log `[REDACTED]`. **Verified live:** 0 raw tokens in the container logs, management-token bodies show `[REDACTED]`.

## 🟠 Harden `initializeHubs`
It used `!!` on the `localIP` attribute, so a hub not exposing `localIP` would NPE-crash the bot at boot — the same all-or-nothing fragility fixed for devices in v3.6. Now each hub initializes independently; one missing `localIP` is skipped with a warning, and only fully-initialized hubs are returned.

## 🟡 HTTP timeouts
The ktor CIO client had none, so a hung/rebooting hub could block a command handler forever. Added connect (10s), request (30s), socket (30s) timeouts — dovetails with the `/update` watcher, which treats a timed-out poll as "still rebooting."

## 🟢 Declarative deploy
Replaced the hand-typed `docker run` (retyped ~6× this session) with:
- `docker-compose.yml` — `restart: unless-stopped`, env from `.env`, same container name.
- `deploy.sh` — build tar → `scp -O` → `docker load` → `docker compose up` on the NAS.
- `.env.example` committed as the descriptor; real `.env` gitignored, lives on the NAS.

## Verified
`./gradlew clean build` green (tests + coverage). **3.8 deployed to the NAS via `deploy.sh` itself** — compose-managed, `unless-stopped`, boots clean (`Init successful, 65 devices loaded`), tokens redacted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3u23Papja4YbdH1xeQNUx