### PR TITLE
Cleanups: dead code, slf4j logging, deviceCount, /refresh hubs, dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Direct Gradle dependencies and plugins (transitive vulns still need manual
+  # constraints — see build.gradle.kts).
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      gradle:
+        patterns: ["*"]
+
+  # Keep GitHub Actions in the workflows up to date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "jbaru.ch"
-version = "3.8"
+version = "3.9"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/CommandHandlers.kt
+++ b/src/main/kotlin/CommandHandlers.kt
@@ -7,9 +7,12 @@ import jbaru.ch.telegram.hubitat.model.Device
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.slf4j.LoggerFactory
 
 object CommandHandlers {
-    
+
+    private val logger = LoggerFactory.getLogger(CommandHandlers::class.java)
+
     suspend fun handleDeviceCommand(
         bot: Bot,
         message: Message,
@@ -41,7 +44,7 @@ object CommandHandlers {
                 }
             },
             onFailure = {
-                it.printStackTrace()
+                logger.warn("Device command '{}' failed: {}", snakeCaseCommand, it.message)
                 it.message.toString()
             }
         )

--- a/src/main/kotlin/DeviceManager.kt
+++ b/src/main/kotlin/DeviceManager.kt
@@ -157,9 +157,8 @@ class DeviceManager(deviceListJson: String) {
     }
 
 
-    override fun toString(): String {
-        return devices.size.toString()
-    }
+    val deviceCount: Int
+        get() = devices.size
 
     private fun initializeCache(devices: List<Device>): List<String> {
         val warnings: MutableList<String> = ArrayList()

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -28,6 +28,7 @@ import com.github.kotlintelegrambot.extensions.filters.Filter
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 
+private val logger = org.slf4j.LoggerFactory.getLogger("jbaru.ch.telegram.hubitat.Main")
 private lateinit var config: BotConfiguration
 private lateinit var hubs: List<Device.Hub>
 private val client = HttpClient(CIO) {
@@ -99,7 +100,7 @@ fun main() {
                 bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = result.fold(
                     onSuccess = { it },
                     onFailure = {
-                        it.printStackTrace()
+                        logger.error("Hub update failed", it)
                         it.message.toString()
                     }
                 ))
@@ -107,10 +108,17 @@ fun main() {
             
             command("refresh") {
                 val refreshResults = runBlocking {
-                    CommandHandlers.handleRefreshCommand(
+                    val results = CommandHandlers.handleRefreshCommand(
                         deviceManager, networkClient,
                         config.makerApiAppId, config.makerApiToken, config.defaultHubIp
                     )
+                    // Re-initialize hubs too, so a hub added/changed since boot is
+                    // picked up (and its ip/managementToken refreshed) without a restart.
+                    hubs = HubOperations.initializeHubs(
+                        deviceManager, networkClient, config.defaultHubIp,
+                        config.makerApiAppId, config.makerApiToken
+                    )
+                    results
                 }
                 bot.sendMessage(
                     chatId = ChatId.fromId(message.chat.id),
@@ -174,11 +182,12 @@ fun main() {
         }
     }
 
-    println("Init successful, $deviceManager devices loaded, start polling")
+    val startupMessage = "Init successful, ${deviceManager.deviceCount} devices loaded, start polling"
+    logger.info(startupMessage)
     if (config.chatId.isNotEmpty()) {
         bot.sendMessage(
             chatId = ChatId.fromId(config.chatId.toLong()),
-            text = "Init successful, $deviceManager devices loaded, start polling"
+            text = startupMessage
         )
     }
     bot.startPolling()

--- a/src/main/kotlin/NetworkClient.kt
+++ b/src/main/kotlin/NetworkClient.kt
@@ -3,7 +3,6 @@ package jbaru.ch.telegram.hubitat
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
-import io.ktor.client.request.put
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.contentType
@@ -12,7 +11,6 @@ import org.slf4j.LoggerFactory
 interface NetworkClient {
     suspend fun get(url: String, params: Map<String, String> = emptyMap()): HttpResponse
     suspend fun getBody(url: String, params: Map<String, String> = emptyMap()): String
-    suspend fun put(url: String, params: Map<String, String> = emptyMap()): HttpResponse
 }
 
 class KtorNetworkClient(private val client: HttpClient) : NetworkClient {
@@ -40,17 +38,6 @@ class KtorNetworkClient(private val client: HttpClient) : NetworkClient {
             logger.info("HTTP Response body preview (${body.length} chars): $preview")
         }
         return body
-    }
-
-    override suspend fun put(url: String, params: Map<String, String>): HttpResponse {
-        logger.info("HTTP PUT: $url with params: ${redact(params)}")
-        val response = client.put(url) {
-            params.forEach { (key, value) ->
-                parameter(key, value)
-            }
-        }
-        logger.info("HTTP Response: status=${response.status}, content-type=${response.contentType()}")
-        return response
     }
 
     companion object {

--- a/src/test/kotlin/NetworkClientTest.kt
+++ b/src/test/kotlin/NetworkClientTest.kt
@@ -13,27 +13,6 @@ import io.ktor.utils.io.ByteReadChannel
 class NetworkClientTest : FunSpec({
     
     context("KtorNetworkClient") {
-        test("put should make PUT request with parameters") {
-            val mockEngine = MockEngine { request ->
-                request.method shouldBe HttpMethod.Put
-                request.url.toString() shouldBe "http://test.com/api?access_token=token123"
-                
-                respond(
-                    content = ByteReadChannel("""{"status": "success"}"""),
-                    status = HttpStatusCode.OK,
-                    headers = headersOf("Content-Type" to listOf("application/json"))
-                )
-            }
-            
-            val client = KtorNetworkClient(HttpClient(mockEngine))
-            val response = client.put(
-                "http://test.com/api",
-                mapOf("access_token" to "token123")
-            )
-            
-            response.status shouldBe HttpStatusCode.OK
-        }
-        
         test("get should make GET request with parameters") {
             val mockEngine = MockEngine { request ->
                 request.method shouldBe HttpMethod.Get


### PR DESCRIPTION
The remaining lower-priority items from the codebase review.

## #8 — Remove dead `put()`
`NetworkClient.put()` was declared and implemented but never called. Removed it and its test.

## #7 — Log through slf4j, not `printStackTrace()`
Both `printStackTrace()` calls (the `/update` failure path in `Main`, the device-command failure path in `CommandHandlers`) now go through slf4j — consistent with the logback setup, and captured properly in `docker logs` instead of raw stderr.

## #6 — `deviceCount` instead of a magic `toString()`
`DeviceManager.toString()` returned a bare device count, and the startup message secretly depended on that (`"$deviceManager devices loaded"`). Replaced with an explicit `deviceCount` property; the startup message now goes through the logger too.

## #4 — `/refresh` refreshes hubs
`hubs` was captured once at boot, so a hub added/changed later wasn't updatable until a restart. `/refresh` now re-initializes hubs alongside devices.

## dependabot.yml
Added weekly grouped version-update PRs for Gradle deps/plugins and GitHub Actions. (Transitive vulns still need the manual constraints in `build.gradle.kts` — Dependabot can't bump what isn't declared.)

## Verified
`./gradlew clean build` green. **3.9 deployed via `deploy.sh`** — boots clean, startup message now logged via slf4j (`Main -- Init successful, 65 devices loaded`), tokens still redacted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3u23Papja4YbdH1xeQNUx