### PR TITLE
Bump version to 3.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "jbaru.ch"
-version = "3.9"
+version = "3.10"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Version bump so the /firmware release (#16) ships as its own image and 3.9 stays as the rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSb8VPARf1rMym2Bs72945