### PR TITLE
Periodic new-firmware notification + live catalog fetch

### DIFF
--- a/.github/scripts/refresh_zooz_catalog.py
+++ b/.github/scripts/refresh_zooz_catalog.py
@@ -6,11 +6,13 @@ compares each against the catalog's Zooz lines (matched by the major version of
 the line's current `latest`), and rewrites the catalog in place when a newer
 file exists. Non-Zooz vendors are never touched.
 
-Prints a human-readable summary and, when GITHUB_OUTPUT is set, emits
-`changed=true|false` plus writes the summary to `catalog-refresh-summary.md`
-for use as a PR body. Exits non-zero on any scrape/parse failure so a broken
-page shape fails the workflow visibly instead of silently reporting "no
-changes".
+Prints a human-readable summary and, when GITHUB_OUTPUT is set, emits two
+flags: `changed` (the catalog file was rewritten - a PR is needed) and `news`
+(anything newsworthy was found, including new hardware lines that need manual
+cataloging - a Telegram ping is warranted). The summary is written to
+`catalog-refresh-summary.md` for use as the PR body and the notification text.
+Exits non-zero on any scrape/parse failure so a broken page shape fails the
+workflow visibly instead of silently reporting "no changes".
 """
 
 import json
@@ -117,6 +119,7 @@ def main() -> None:
     if github_output:
         with open(github_output, "a") as handle:
             handle.write(f"changed={'true' if catalog_changed else 'false'}\n")
+            handle.write(f"news={'true' if changes else 'false'}\n")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/firmware-catalog-refresh.yml
+++ b/.github/workflows/firmware-catalog-refresh.yml
@@ -2,8 +2,8 @@ name: Firmware catalog refresh
 
 on:
   schedule:
-    # Weekly, Monday 06:00 UTC
-    - cron: '0 6 * * 1'
+    # Twice a month, 06:00 UTC on the 1st and 15th
+    - cron: '0 6 1,15 * *'
   workflow_dispatch:
 
 jobs:
@@ -23,6 +23,7 @@ jobs:
         run: python3 .github/scripts/refresh_zooz_catalog.py
 
       - name: Open PR with catalog changes
+        id: pr
         if: steps.refresh.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
@@ -33,3 +34,29 @@ jobs:
           add-paths: src/main/resources/zwave-firmware-catalog.json
           labels: enhancement
           delete-branch: true
+
+      # The bot reads the catalog from main at /firmware time, so merging the
+      # PR is all it takes for the new versions to reach the device report.
+      - name: Notify Telegram
+        if: steps.refresh.outputs.news == 'true'
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          CHAT_ID: ${{ secrets.CHAT_ID }}
+          PR_URL: ${{ steps.pr.outputs.pull-request-url }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BOT_TOKEN}" ] || [ -z "${CHAT_ID}" ]; then
+            echo "BOT_TOKEN / CHAT_ID repository secrets are not set - cannot notify" >&2
+            exit 1
+          fi
+          text="$(cat catalog-refresh-summary.md)"
+          if [ -n "${PR_URL}" ]; then
+            text="${text}
+
+Catalog PR: ${PR_URL}
+Merge it, then /firmware shows which devices it applies to."
+          fi
+          curl -sf -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${CHAT_ID}" \
+            --data-urlencode "text=${text}" > /dev/null
+          echo "Telegram notification sent"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
   * `/cancel_alerts` - Cancels all alerts in HSM.
   * `/update` - Updates all hubs for which Hub Information Drivers are exposed in the Maker API of `hubitat.local`.
   * `/reboot [Hub Information Driver v3 instance name]` - Reboots a specified hub.
-  * `/firmware` - Reports every Z-Wave device whose firmware is behind the latest vendor version, with download links. Report-only: it compares installed firmware against the curated catalog in `src/main/resources/zwave-firmware-catalog.json` (refreshed weekly from the Zooz KB page via a scheduled GitHub Action) and refuses to guess when the hardware line is ambiguous — flashing the wrong 700-series/800LR image can brick a device.
+  * `/firmware` - Reports every Z-Wave device whose firmware is behind the latest vendor version, with download links. Report-only: it compares installed firmware against the curated catalog in `src/main/resources/zwave-firmware-catalog.json` and refuses to guess when the hardware line is ambiguous — flashing the wrong 700-series/800LR image can brick a device. The catalog is read live from this repo's `main` branch (bundled copy as offline fallback), so merging a catalog PR is enough — no bot redeploy. A scheduled GitHub Action checks the Zooz KB page twice a month and, when new vendor firmware appears, opens the catalog PR and pings the Telegram chat (requires `BOT_TOKEN` and `CHAT_ID` repository secrets).
 
 
 ## Device Name Notations:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "jbaru.ch"
-version = "3.10"
+version = "3.11"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/FirmwareOperations.kt
+++ b/src/main/kotlin/FirmwareOperations.kt
@@ -53,6 +53,8 @@ object FirmwareOperations {
     private val json = Json { ignoreUnknownKeys = true }
 
     private const val CATALOG_RESOURCE = "/zwave-firmware-catalog.json"
+    internal const val CATALOG_URL =
+        "https://raw.githubusercontent.com/jbaruch/tg-hubitat-bot/main/src/main/resources/zwave-firmware-catalog.json"
     private const val MAX_MESSAGE_LENGTH = 3900
 
     fun loadCatalog(): FirmwareCatalog {
@@ -61,11 +63,25 @@ object FirmwareOperations {
         return json.decodeFromString<FirmwareCatalog>(resource.bufferedReader().readText())
     }
 
+    /**
+     * The catalog is read from the repo's main branch so that merging a
+     * catalog-refresh PR is enough for /firmware to know the new versions — no
+     * bot redeploy. The bundled copy is the offline fallback, and the report
+     * header says so when it is used.
+     */
+    suspend fun fetchCatalog(networkClient: NetworkClient): Pair<FirmwareCatalog, String?> =
+        try {
+            json.decodeFromString<FirmwareCatalog>(networkClient.getBody(CATALOG_URL)) to null
+        } catch (e: Exception) {
+            logger.warn("Could not fetch live firmware catalog, using bundled copy: {}", e.message)
+            loadCatalog() to "bundled fallback — live catalog unreachable"
+        }
+
     suspend fun checkFirmware(
         hubs: List<Device.Hub>,
         networkClient: NetworkClient
     ): List<String> {
-        val catalog = loadCatalog()
+        val (catalog, catalogNote) = fetchCatalog(networkClient)
         val findings = mutableListOf<FirmwareFinding>()
         val hubErrors = mutableListOf<String>()
 
@@ -79,7 +95,7 @@ object FirmwareOperations {
             }
         }
 
-        return formatReport(findings, catalog, hubErrors)
+        return formatReport(findings, catalog, hubErrors, catalogNote)
     }
 
     suspend fun collectZwaveDevices(
@@ -230,14 +246,16 @@ object FirmwareOperations {
     fun formatReport(
         findings: List<FirmwareFinding>,
         catalog: FirmwareCatalog,
-        hubErrors: List<String> = emptyList()
+        hubErrors: List<String> = emptyList(),
+        catalogNote: String? = null
     ): List<String> {
         val byStatus = findings.groupBy { it.status }
         val sections = mutableListOf<String>()
 
         val hubCount = findings.map { it.device.hubLabel }.distinct().size
+        val catalogSuffix = if (catalogNote != null) " ($catalogNote)" else ""
         sections.add(
-            "Z-Wave firmware report: ${findings.size} devices on $hubCount hub(s), catalog ${catalog.catalogVersion}"
+            "Z-Wave firmware report: ${findings.size} devices on $hubCount hub(s), catalog ${catalog.catalogVersion}$catalogSuffix"
         )
 
         byStatus[FirmwareStatus.UPDATE_AVAILABLE]?.let { updates ->

--- a/src/test/kotlin/FirmwareOperationsTest.kt
+++ b/src/test/kotlin/FirmwareOperationsTest.kt
@@ -242,6 +242,36 @@ class FirmwareOperationsTest : FunSpec({
         }
     }
 
+    context("catalog fetching") {
+        test("uses the live catalog from the repo main branch when reachable") {
+            val networkClient = mock<NetworkClient>()
+            whenever(networkClient.getBody(argThat { equals(FirmwareOperations.CATALOG_URL) }, any()))
+                .thenReturn("""{"catalogVersion": "live-version", "entries": []}""")
+
+            val (catalog, note) = FirmwareOperations.fetchCatalog(networkClient)
+
+            catalog.catalogVersion shouldBe "live-version"
+            note shouldBe null
+        }
+
+        test("falls back to the bundled catalog when the live one is unreachable, and says so") {
+            val networkClient = mock<NetworkClient>()
+            whenever(networkClient.getBody(any(), any())).thenThrow(RuntimeException("no route to host"))
+
+            val (catalog, note) = FirmwareOperations.fetchCatalog(networkClient)
+
+            catalog.entries.shouldNotBeEmpty()
+            note.shouldNotBeNull() shouldContain "bundled fallback"
+        }
+
+        test("the fallback note surfaces in the report header") {
+            val report = FirmwareOperations.formatReport(
+                emptyList(), testCatalog, catalogNote = "bundled fallback — live catalog unreachable"
+            ).joinToString("\n\n")
+            report shouldContain "catalog test (bundled fallback"
+        }
+    }
+
     context("collecting devices from a hub") {
         val hub = Device.Hub(1, "Test Hub", ip = "192.168.1.50")
 


### PR DESCRIPTION
Follow-up to #16, refining the flow per discussion: the *web* check (is there new vendor firmware?) is the periodic one; the *device* check stays on-demand behind `/firmware`.

## The flow

1. Twice a month (1st/15th) the existing catalog-refresh Action scrapes the Zooz KB page.
2. Anything new → Telegram ping through the bot ("new firmware, pay attention") including the catalog PR link. Nothing new → silence.
3. You merge the catalog PR whenever.
4. Back home, `/firmware` reads the catalog **live from main** (bundled copy as offline fallback, flagged in the report header) and shows exactly which devices the new firmware applies to. No bot redeploy needed.

## Changes

- Workflow: biweekly cron, `news` output (covers new-hardware-line discoveries that don't rewrite the catalog file), Telegram notify step that fails visibly if `BOT_TOKEN`/`CHAT_ID` secrets are missing.
- Bot: `fetchCatalog` pulls from raw.githubusercontent.com main with bundled fallback; report header notes when the fallback was used.
- Version 3.11; README updated.

**Requires two repository secrets** (blocked from setting them myself): `BOT_TOKEN`, `CHAT_ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSb8VPARf1rMym2Bs72945