### PR TITLE
Fix invalid YAML in catalog-refresh workflow notify step

### DIFF
--- a/.github/workflows/firmware-catalog-refresh.yml
+++ b/.github/workflows/firmware-catalog-refresh.yml
@@ -51,10 +51,7 @@ jobs:
           fi
           text="$(cat catalog-refresh-summary.md)"
           if [ -n "${PR_URL}" ]; then
-            text="${text}
-
-Catalog PR: ${PR_URL}
-Merge it, then /firmware shows which devices it applies to."
+            text="$(printf '%s\n\nCatalog PR: %s\nMerge it, then /firmware shows which devices it applies to.' "${text}" "${PR_URL}")"
           fi
           curl -sf -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
             --data-urlencode "chat_id=${CHAT_ID}" \


### PR DESCRIPTION
The notify step's multi-line Telegram message had continuation lines at column 0 inside the `run: |` block, which ends the block scalar and makes the whole workflow file invalid — GitHub has been emitting jobless failure runs for `firmware-catalog-refresh.yml` on every push since #18. Message is now built with `printf`. All three workflow files validated locally with a YAML parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSb8VPARf1rMym2Bs72945