### PR TITLE
fix(security): enforce chat allowlist and require leading slash for device commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Quick Start
 1. Set up Maker API on `hubitat.local` or use `DEFAULT_HUB_IP` environment variable to specify the IP of your primary hub.
 2. Configure mandatory environment variables: `MAKER_API_APP_ID`, `MAKER_API_TOKEN`, `BOT_TOKEN`.
-  * If you know the ID of your DM chat with your bot, you can add it as `CHAT_ID` variable.
+  * If you know the ID of your DM chat with your bot, you can add it as `CHAT_ID` variable. This also locks the bot down to that chat (see `ALLOWED_CHAT_IDS` below).
   * If your primary hub is not using `hubitat.local` DNS entry, use `DEFAULT_HUB_IP` to specify the ip.
 3. Deploy the Docker container.
 4. Start sending commands to your bot!
@@ -62,6 +62,7 @@ You can refer to devices in several ways:
     * `CHAT_ID` - The ID of your DM chat with the Bot (or other chat the bot is added to).
       If you use that variable, the bot will be able to proactively send information to the chat. If you don't use it, it will only reply to your messages.
       There are number of ways to find this ID, some of them are listed [here](https://stackoverflow.com/questions/32423837/telegram-bot-how-to-get-a-group-chat-id).
+    * `ALLOWED_CHAT_IDS` - Comma-separated list of chat IDs allowed to command the bot. When set (or when `CHAT_ID` is set), commands from any other chat are dropped and logged. **Strongly recommended** — without it, anyone who finds the bot's username can control your hub. `CHAT_ID` is automatically included in the allowlist.
     * `DEFAULT_HUB_IP` – The IP of the hub the Maker API app is installed on. Defaults to DNS hostname of `hubitat.local`.
 9. Deploy the Docker image:
    - Load the Docker image: `docker load < tg-hubitat-bot-docker-image.tar`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,5 @@ services:
       MAKER_API_APP_ID: ${MAKER_API_APP_ID}
       MAKER_API_TOKEN: ${MAKER_API_TOKEN}
       CHAT_ID: ${CHAT_ID:-}
+      ALLOWED_CHAT_IDS: ${ALLOWED_CHAT_IDS:-}
       DEFAULT_HUB_IP: ${DEFAULT_HUB_IP:-hubitat.local}

--- a/src/main/kotlin/BotConfiguration.kt
+++ b/src/main/kotlin/BotConfiguration.kt
@@ -7,17 +7,50 @@ data class BotConfiguration(
     val makerApiAppId: String,
     val makerApiToken: String,
     val chatId: String = "",
-    val defaultHubIp: String = "hubitat.local"
+    val defaultHubIp: String = "hubitat.local",
+    val allowedChatIds: Set<Long> = emptySet()
 ) {
+    /**
+     * With an allowlist configured, only listed chats may command the bot
+     * (fail closed). With no allowlist at all, the bot stays open to any chat
+     * for backward compatibility - Main logs a loud warning in that case.
+     */
+    fun isChatAllowed(chatId: Long): Boolean =
+        allowedChatIds.isEmpty() || chatId in allowedChatIds
+
     companion object {
         fun fromEnvironment(): BotConfiguration {
+            val chatId = getenv("CHAT_ID") ?: ""
             return BotConfiguration(
                 botToken = getenv("BOT_TOKEN") ?: throw IllegalStateException("BOT_TOKEN not set"),
                 makerApiAppId = getenv("MAKER_API_APP_ID") ?: throw IllegalStateException("MAKER_API_APP_ID not set"),
                 makerApiToken = getenv("MAKER_API_TOKEN") ?: throw IllegalStateException("MAKER_API_TOKEN not set"),
-                chatId = getenv("CHAT_ID") ?: "",
-                defaultHubIp = getenv("DEFAULT_HUB_IP") ?: "hubitat.local"
+                chatId = chatId,
+                defaultHubIp = getenv("DEFAULT_HUB_IP") ?: "hubitat.local",
+                allowedChatIds = parseAllowedChatIds(chatId, getenv("ALLOWED_CHAT_IDS"))
             )
+        }
+
+        /**
+         * The allowlist is the union of ALLOWED_CHAT_IDS (comma-separated) and
+         * CHAT_ID. Both are validated at startup so a typo fails fast here,
+         * not after all devices have already loaded.
+         */
+        internal fun parseAllowedChatIds(chatIdEnv: String?, allowlistEnv: String?): Set<Long> {
+            val ids = mutableSetOf<Long>()
+            if (!chatIdEnv.isNullOrBlank()) {
+                ids.add(
+                    chatIdEnv.trim().toLongOrNull()
+                        ?: throw IllegalStateException("CHAT_ID is not a valid chat id: '$chatIdEnv'")
+                )
+            }
+            allowlistEnv?.split(',')?.map { it.trim() }?.filter { it.isNotEmpty() }?.forEach { entry ->
+                ids.add(
+                    entry.toLongOrNull()
+                        ?: throw IllegalStateException("ALLOWED_CHAT_IDS contains an invalid chat id: '$entry'")
+                )
+            }
+            return ids
         }
     }
 }

--- a/src/main/kotlin/BotConfiguration.kt
+++ b/src/main/kotlin/BotConfiguration.kt
@@ -20,7 +20,10 @@ data class BotConfiguration(
 
     companion object {
         fun fromEnvironment(): BotConfiguration {
-            val chatId = getenv("CHAT_ID") ?: ""
+            // Trimmed so the stored value matches what the allowlist validated -
+            // an untrimmed value would pass validation here and still crash the
+            // startup-message toLong() later.
+            val chatId = (getenv("CHAT_ID") ?: "").trim()
             return BotConfiguration(
                 botToken = getenv("BOT_TOKEN") ?: throw IllegalStateException("BOT_TOKEN not set"),
                 makerApiAppId = getenv("MAKER_API_APP_ID") ?: throw IllegalStateException("MAKER_API_APP_ID not set"),

--- a/src/main/kotlin/CommandHandlers.kt
+++ b/src/main/kotlin/CommandHandlers.kt
@@ -27,7 +27,8 @@ object CommandHandlers {
             return "Please specify a device name for the command."
         }
 
-        val snakeCaseCommand = parts[0].removePrefix("/")
+        // Strip the group-chat mention form (/on@BotName) to the bare command.
+        val snakeCaseCommand = parts[0].removePrefix("/").substringBefore("@")
         val camelCaseCommand = snakeCaseCommand.snakeToCamelCase()
         val deviceName = parts[1]
         val args = parts.drop(2)

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -62,7 +62,8 @@ fun main() {
 
         dispatch {
 
-            message(DeviceCommandFilter()) {
+            message(DeviceCommandFilter { deviceManager }) {
+                if (!isAuthorized(message)) return@message
                 val result = runBlocking {
                     CommandHandlers.handleDeviceCommand(
                         bot, message, deviceManager, networkClient,
@@ -73,6 +74,7 @@ fun main() {
             }
 
             command("cancel_alerts") {
+                if (!isAuthorized(message)) return@command
                 val result = runBlocking {
                     CommandHandlers.handleCancelAlertsCommand(
                         networkClient, config.makerApiAppId, config.makerApiToken, config.defaultHubIp
@@ -82,6 +84,7 @@ fun main() {
             }
             
             command("update") {
+                if (!isAuthorized(message)) return@command
                 val result = runBlocking {
                     HubOperations.updateHubsWithPolling(
                         hubs,
@@ -107,6 +110,7 @@ fun main() {
             }
             
             command("firmware") {
+                if (!isAuthorized(message)) return@command
                 val chatId = ChatId.fromId(message.chat.id)
                 val messages = runBlocking {
                     try {
@@ -120,6 +124,7 @@ fun main() {
             }
 
             command("refresh") {
+                if (!isAuthorized(message)) return@command
                 val refreshResults = runBlocking {
                     val results = CommandHandlers.handleRefreshCommand(
                         deviceManager, networkClient,
@@ -140,6 +145,7 @@ fun main() {
             }
             
             command("list") {
+                if (!isAuthorized(message)) return@command
                 val chatId = ChatId.fromId(message.chat.id)
                 val deviceLists = runBlocking {
                     CommandHandlers.handleListCommand(deviceManager)
@@ -154,6 +160,7 @@ fun main() {
             }
 
             command("get_open_sensors") {
+                if (!isAuthorized(message)) return@command
                 val response = runBlocking {
                     CommandHandlers.handleGetOpenSensorsCommand(
                         deviceManager, networkClient,
@@ -164,6 +171,7 @@ fun main() {
             }
             
             command("get_mode") {
+                if (!isAuthorized(message)) return@command
                 val result = runBlocking {
                     CommandHandlers.handleGetModeCommand(
                         networkClient, config.makerApiAppId,
@@ -174,6 +182,7 @@ fun main() {
             }
             
             command("list_modes") {
+                if (!isAuthorized(message)) return@command
                 val result = runBlocking {
                     CommandHandlers.handleListModesCommand(
                         networkClient, config.makerApiAppId,
@@ -184,6 +193,7 @@ fun main() {
             }
             
             command("set_mode") {
+                if (!isAuthorized(message)) return@command
                 val result = runBlocking {
                     CommandHandlers.handleSetModeCommand(
                         message, networkClient, config.makerApiAppId,
@@ -193,6 +203,13 @@ fun main() {
                 bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = result)
             }
         }
+    }
+
+    if (config.allowedChatIds.isEmpty()) {
+        logger.warn(
+            "No ALLOWED_CHAT_IDS or CHAT_ID configured - the bot will accept commands from ANY chat. " +
+                "Set ALLOWED_CHAT_IDS to lock it down."
+        )
     }
 
     val startupMessage = "Init successful, ${deviceManager.deviceCount} devices loaded, start polling"
@@ -213,9 +230,25 @@ private suspend fun getDevicesJson(): String =
     )
 
 
-class DeviceCommandFilter : Filter {
+private fun isAuthorized(message: Message): Boolean {
+    val allowed = config.isChatAllowed(message.chat.id)
+    if (!allowed) {
+        logger.warn(
+            "Dropping command from unauthorized chat {} (user {}): {}",
+            message.chat.id, message.from?.id, message.text
+        )
+    }
+    return allowed
+}
+
+class DeviceCommandFilter(private val deviceManagerProvider: () -> DeviceManager) : Filter {
     override fun Message.predicate(): Boolean {
-        val command = text?.split(" ")?.firstOrNull()?.removePrefix("/")
-        return command != null && deviceManager.isDeviceCommand(command.snakeToCamelCase())
+        // Only explicit commands qualify: a leading slash is required so plain
+        // chat text ("on kitchen") is never interpreted as a device command.
+        val firstToken = text?.split(" ")?.firstOrNull() ?: return false
+        if (!firstToken.startsWith("/")) return false
+        // In group chats commands arrive as /on@BotName - strip the mention.
+        val command = firstToken.removePrefix("/").substringBefore("@")
+        return command.isNotEmpty() && deviceManagerProvider().isDeviceCommand(command.snakeToCamelCase())
     }
 }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -41,6 +41,8 @@ private val client = HttpClient(CIO) {
 }
 private lateinit var networkClient: NetworkClient
 private lateinit var deviceManager: DeviceManager
+// Resolved via getMe() at startup; used to validate /cmd@BotName mentions.
+@Volatile private var botUsername: String? = null
 
 fun main() {
     config = BotConfiguration.fromEnvironment()
@@ -62,7 +64,7 @@ fun main() {
 
         dispatch {
 
-            message(DeviceCommandFilter { deviceManager }) {
+            message(DeviceCommandFilter({ deviceManager })) {
                 if (!isAuthorized(message)) return@message
                 val result = runBlocking {
                     CommandHandlers.handleDeviceCommand(
@@ -205,6 +207,11 @@ fun main() {
         }
     }
 
+    botUsername = bot.getMe().getOrNull()?.username
+    if (botUsername == null) {
+        logger.warn("Could not resolve the bot's username via getMe(); mention-form commands (/cmd@BotName) will be ignored")
+    }
+
     if (config.allowedChatIds.isEmpty()) {
         logger.warn(
             "No ALLOWED_CHAT_IDS or CHAT_ID configured - the bot will accept commands from ANY chat. " +
@@ -243,13 +250,23 @@ private fun isAuthorized(message: Message): Boolean {
     return allowed
 }
 
-class DeviceCommandFilter(private val deviceManagerProvider: () -> DeviceManager) : Filter {
+class DeviceCommandFilter(
+    private val deviceManagerProvider: () -> DeviceManager,
+    private val botUsernameProvider: () -> String? = { botUsername }
+) : Filter {
     override fun Message.predicate(): Boolean {
         // Only explicit commands qualify: a leading slash is required so plain
         // chat text ("on kitchen") is never interpreted as a device command.
         val firstToken = text?.split(" ")?.firstOrNull() ?: return false
         if (!firstToken.startsWith("/")) return false
-        // In group chats commands arrive as /on@BotName - strip the mention.
+        // In group chats commands arrive as /on@BotName. A mention addressed
+        // to a DIFFERENT bot (privacy mode off delivers those too) must not
+        // drive this one; if our own username is unknown, reject mention forms
+        // rather than guess.
+        val mention = firstToken.substringAfter("@", "")
+        if (mention.isNotEmpty() && !mention.equals(botUsernameProvider(), ignoreCase = true)) {
+            return false
+        }
         val command = firstToken.removePrefix("/").substringBefore("@")
         return command.isNotEmpty() && deviceManagerProvider().isDeviceCommand(command.snakeToCamelCase())
     }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -233,9 +233,11 @@ private suspend fun getDevicesJson(): String =
 private fun isAuthorized(message: Message): Boolean {
     val allowed = config.isChatAllowed(message.chat.id)
     if (!allowed) {
+        // Log only the command token: full text from a stranger is both a
+        // privacy leak and a log-spam vector.
         logger.warn(
             "Dropping command from unauthorized chat {} (user {}): {}",
-            message.chat.id, message.from?.id, message.text
+            message.chat.id, message.from?.id, message.text?.split(" ")?.firstOrNull()?.take(64)
         )
     }
     return allowed

--- a/src/test/kotlin/BotConfigurationTest.kt
+++ b/src/test/kotlin/BotConfigurationTest.kt
@@ -1,5 +1,6 @@
 package jbaru.ch.telegram.hubitat
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -30,5 +31,42 @@ class BotConfigurationTest : FunSpec({
         
         config.chatId shouldBe ""
         config.defaultHubIp shouldBe "hubitat.local"
+        config.allowedChatIds shouldBe emptySet()
+    }
+
+    test("empty allowlist allows any chat (backward compatible)") {
+        val config = BotConfiguration("t", "a", "m")
+        config.isChatAllowed(12345L) shouldBe true
+        config.isChatAllowed(-99L) shouldBe true
+    }
+
+    test("configured allowlist fails closed for unlisted chats") {
+        val config = BotConfiguration("t", "a", "m", allowedChatIds = setOf(111L, 222L))
+        config.isChatAllowed(111L) shouldBe true
+        config.isChatAllowed(222L) shouldBe true
+        config.isChatAllowed(333L) shouldBe false
+    }
+
+    test("parseAllowedChatIds unions CHAT_ID and ALLOWED_CHAT_IDS") {
+        BotConfiguration.parseAllowedChatIds("111", "222, 333") shouldBe setOf(111L, 222L, 333L)
+    }
+
+    test("parseAllowedChatIds handles missing values") {
+        BotConfiguration.parseAllowedChatIds(null, null) shouldBe emptySet()
+        BotConfiguration.parseAllowedChatIds("", null) shouldBe emptySet()
+        BotConfiguration.parseAllowedChatIds(null, "42") shouldBe setOf(42L)
+        BotConfiguration.parseAllowedChatIds("-100123", null) shouldBe setOf(-100123L)
+    }
+
+    test("parseAllowedChatIds fails fast on garbage CHAT_ID") {
+        shouldThrow<IllegalStateException> {
+            BotConfiguration.parseAllowedChatIds("not-a-number", null)
+        }
+    }
+
+    test("parseAllowedChatIds fails fast on garbage allowlist entry") {
+        shouldThrow<IllegalStateException> {
+            BotConfiguration.parseAllowedChatIds(null, "111,oops")
+        }
     }
 })

--- a/src/test/kotlin/DeviceCommandFilterTest.kt
+++ b/src/test/kotlin/DeviceCommandFilterTest.kt
@@ -7,46 +7,66 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
 class DeviceCommandFilterTest : FunSpec({
-    
+
     lateinit var deviceManager: DeviceManager
     lateinit var filter: DeviceCommandFilter
-    
+
     beforeEach {
-        // Create a mock device manager with some known commands
         deviceManager = mock {
             on { isDeviceCommand("on") } doReturn true
             on { isDeviceCommand("off") } doReturn true
+            on { isDeviceCommand("setLevel") } doReturn true
             on { isDeviceCommand("cancelAlerts") } doReturn false
             on { isDeviceCommand("unknown") } doReturn false
         }
-        // Note: DeviceCommandFilter uses the global deviceManager, so we can't easily inject it
-        // These tests verify the filter logic structure
+        filter = DeviceCommandFilter { deviceManager }
     }
-    
-    test("should return false for system command") {
-        val message = mock<Message> {
-            on { text } doReturn "/cancel_alerts"
-        }
-        
-        // System commands like cancel_alerts should not be device commands
-        // This test verifies the structure, actual behavior depends on deviceManager state
+
+    fun messageWithText(value: String?): Message = mock {
+        on { text } doReturn value
     }
-    
-    test("should return false for null message text") {
-        val message = mock<Message> {
-            on { text } doReturn null
-        }
-        
-        // Null text should return false
-        // This test verifies the filter handles null gracefully
+
+    fun matches(text: String?): Boolean = with(filter) {
+        messageWithText(text).predicate()
     }
-    
-    test("should return false for empty message text") {
-        val message = mock<Message> {
-            on { text } doReturn ""
-        }
-        
-        // Empty text should return false
-        // This test verifies the filter handles empty strings
+
+    test("matches a device command with a leading slash") {
+        matches("/on kitchen") shouldBe true
+    }
+
+    test("converts snake_case commands before lookup") {
+        matches("/set_level kitchen 50") shouldBe true
+    }
+
+    test("does not match without a leading slash") {
+        matches("on kitchen") shouldBe false
+    }
+
+    test("does not match system commands") {
+        matches("/cancel_alerts") shouldBe false
+    }
+
+    test("does not match unknown commands") {
+        matches("/unknown kitchen") shouldBe false
+    }
+
+    test("does not match null text") {
+        matches(null) shouldBe false
+    }
+
+    test("does not match empty text") {
+        matches("") shouldBe false
+    }
+
+    test("does not match a bare slash") {
+        matches("/") shouldBe false
+    }
+
+    test("matches the group-chat mention form") {
+        matches("/on@MyHomeBot kitchen") shouldBe true
+    }
+
+    test("does not match a mention of an unknown command") {
+        matches("/unknown@MyHomeBot kitchen") shouldBe false
     }
 })

--- a/src/test/kotlin/DeviceCommandFilterTest.kt
+++ b/src/test/kotlin/DeviceCommandFilterTest.kt
@@ -19,7 +19,7 @@ class DeviceCommandFilterTest : FunSpec({
             on { isDeviceCommand("cancelAlerts") } doReturn false
             on { isDeviceCommand("unknown") } doReturn false
         }
-        filter = DeviceCommandFilter { deviceManager }
+        filter = DeviceCommandFilter({ deviceManager }, { "MyHomeBot" })
     }
 
     fun messageWithText(value: String?): Message = mock {
@@ -68,5 +68,21 @@ class DeviceCommandFilterTest : FunSpec({
 
     test("does not match a mention of an unknown command") {
         matches("/unknown@MyHomeBot kitchen") shouldBe false
+    }
+
+    test("does not match a mention addressed to a different bot") {
+        matches("/on@OtherBot kitchen") shouldBe false
+    }
+
+    test("matches the mention case-insensitively") {
+        matches("/on@myhomebot kitchen") shouldBe true
+    }
+
+    test("rejects mention forms when own username is unknown") {
+        val anonymous = DeviceCommandFilter({ deviceManager }, { null })
+        with(anonymous) {
+            messageWithText("/on@MyHomeBot kitchen").predicate() shouldBe false
+            messageWithText("/on kitchen").predicate() shouldBe true
+        }
     }
 })


### PR DESCRIPTION
## Summary
- Adds `ALLOWED_CHAT_IDS` (comma-separated, unioned with `CHAT_ID`) and gates every command handler on it — fail-closed when configured, loud startup warning when not. Closes #22
- `DeviceCommandFilter` now requires a leading `/` (plain text like `on kitchen` no longer triggers commands) and handles the `/on@BotName` group mention form. Closes #29
- `CHAT_ID`/`ALLOWED_CHAT_IDS` are validated at startup so a typo fails fast instead of crashing after device load (part of #33)
- `DeviceCommandFilter` takes an injected `DeviceManager` provider; the empty test stubs are replaced with real predicate tests (part of #33)

## Test plan
- [x] `./gradlew test` green locally
- [x] New tests: allowlist parsing/union/fail-fast, filter slash requirement, mention form, unknown/system commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSb8VPARf1rMym2Bs72945