### PR TITLE
chore(tessl): add coding-policy dep, drop vendored mode

### DIFF
--- a/tessl.json
+++ b/tessl.json
@@ -1,7 +1,9 @@
 {
   "name": "tg-hubitat-bot",
-  "mode": "vendored",
   "dependencies": {
+    "jbaruch/coding-policy": {
+      "version": "0.3.109"
+    },
     "jbaruch/hubitat-dev": {
       "version": "0.1.18"
     }


### PR DESCRIPTION
## What

Enroll `tg-hubitat-bot` in the `jbaruch/coding-policy` plugin (pinned `@0.3.109`) so the fleet coding rules load for local agents, and remove `"mode": "vendored"` from `tessl.json`.

## Why drop vendored mode

`.tessl/` is already fully gitignored — no plugin content was ever committed. `mode: vendored` only contradicted that gitignore. Dropping it puts the repo on the standard npm-style model (commit the manifest, `tessl install` materializes `.tessl/plugins/` at runtime), which is what coding-policy's own `dependency-management` **No Vendoring** rule requires.

## Scope
- `tessl.json` only — added the `coding-policy` dependency, removed the `mode` key. `hubitat-dev` pin unchanged (`0.1.18`).
- `.tessl/` content is gitignored, so it's not in the diff.

## Verification
- `tessl install` resolves both plugins cleanly (`coding-policy@0.3.109`, `hubitat-dev@0.1.18`).

Follow-up (separate PRs): wire the central fleet policy reviewer (`install-reviewer`), and adopt a Kotlin diagnostics gate per `language-diagnostics` "Adopting on a Dirty Tree".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGeBDNcz72DVw61VTphuCm