### PR TITLE
fix(commands): support multi-word device names

### DIFF
--- a/src/main/kotlin/CommandHandlers.kt
+++ b/src/main/kotlin/CommandHandlers.kt
@@ -29,25 +29,50 @@ object CommandHandlers {
 
         val snakeCaseCommand = parts[0].removePrefix("/")
         val camelCaseCommand = snakeCaseCommand.snakeToCamelCase()
-        val deviceName = parts[1]
-        val args = parts.drop(2)
+        val tokens = parts.drop(1)
+        val fullQuery = tokens.joinToString(" ")
 
-        return deviceManager.findDevice(deviceName, camelCaseCommand).fold(
-            onSuccess = { device ->
-                val argCount = device.supportedOps[camelCaseCommand]
-                if (argCount == null) {
-                    "Command '/$snakeCaseCommand' is not supported by device '${device.label}'"
-                } else if (args.size != argCount) {
-                    "Invalid number of arguments for /$snakeCaseCommand. Expected $argCount argument(s)."
-                } else {
-                    runDeviceCommand(device, camelCaseCommand, args, networkClient, makerApiAppId, makerApiToken, defaultHubIp)
+        // Device labels are multi-word ("Kitchen Lights", "Front Door Button"),
+        // so the device/args boundary is not fixed. Try the longest possible
+        // name first and shrink until a known device with the right trailing
+        // argument count matches; the longest match wins so a device whose name
+        // prefixes another's never steals the query.
+        var mismatchError: String? = null
+        var unsupportedError: String? = null
+
+        for (i in tokens.size downTo 1) {
+            val name = tokens.take(i).joinToString(" ")
+            val args = tokens.drop(i)
+            deviceManager.findDevice(name, camelCaseCommand).fold(
+                onSuccess = { device ->
+                    val argCount = device.supportedOps[camelCaseCommand]
+                    if (argCount == null) {
+                        if (unsupportedError == null) {
+                            unsupportedError =
+                                "Command '/$snakeCaseCommand' is not supported by device '${device.label}'"
+                        }
+                    } else if (args.size == argCount) {
+                        return runDeviceCommand(
+                            device, camelCaseCommand, args,
+                            networkClient, makerApiAppId, makerApiToken, defaultHubIp
+                        )
+                    } else if (mismatchError == null) {
+                        mismatchError =
+                            "Invalid number of arguments for /$snakeCaseCommand. Expected $argCount argument(s)."
+                    }
+                },
+                onFailure = {
+                    val message = it.message ?: ""
+                    if (message.contains("not supported") && unsupportedError == null) {
+                        unsupportedError = message
+                    }
                 }
-            },
-            onFailure = {
-                logger.warn("Device command '{}' failed: {}", snakeCaseCommand, it.message)
-                it.message.toString()
-            }
-        )
+            )
+        }
+
+        val error = mismatchError ?: unsupportedError ?: "No device found for query: $fullQuery"
+        logger.warn("Device command '{}' failed: {}", snakeCaseCommand, error)
+        return error
     }
     
     suspend fun handleListCommand(deviceManager: DeviceManager): Map<String, String> {

--- a/src/main/kotlin/CommandHandlers.kt
+++ b/src/main/kotlin/CommandHandlers.kt
@@ -45,13 +45,10 @@ object CommandHandlers {
             val args = tokens.drop(i)
             deviceManager.findDevice(name, camelCaseCommand).fold(
                 onSuccess = { device ->
-                    val argCount = device.supportedOps[camelCaseCommand]
-                    if (argCount == null) {
-                        if (unsupportedError == null) {
-                            unsupportedError =
-                                "Command '/$snakeCaseCommand' is not supported by device '${device.label}'"
-                        }
-                    } else if (args.size == argCount) {
+                    // findDevice only succeeds when the device supports the
+                    // command, so the op is guaranteed present here.
+                    val argCount = device.supportedOps.getValue(camelCaseCommand)
+                    if (args.size == argCount) {
                         return runDeviceCommand(
                             device, camelCaseCommand, args,
                             networkClient, makerApiAppId, makerApiToken, defaultHubIp
@@ -62,9 +59,10 @@ object CommandHandlers {
                     }
                 },
                 onFailure = {
-                    val message = it.message ?: ""
-                    if (message.contains("not supported") && unsupportedError == null) {
-                        unsupportedError = message
+                    // findDevice signals "device exists but can't do this" with
+                    // IllegalArgumentException; anything else is "not found".
+                    if (it is IllegalArgumentException && unsupportedError == null) {
+                        unsupportedError = it.message
                     }
                 }
             )

--- a/src/main/kotlin/CommandHandlers.kt
+++ b/src/main/kotlin/CommandHandlers.kt
@@ -22,7 +22,9 @@ object CommandHandlers {
         makerApiToken: String,
         defaultHubIp: String
     ): String {
-        val parts = message.text?.split(" ") ?: return "Please specify a device name for the command."
+        // Trim + split on runs of whitespace: "/on " or doubled spaces must not
+        // produce empty tokens that the multi-token name search would probe.
+        val parts = message.text?.trim()?.split(Regex("\\s+")) ?: emptyList()
         if (parts.size < 2) {
             return "Please specify a device name for the command."
         }

--- a/src/test/kotlin/CommandHandlersPropertyTest.kt
+++ b/src/test/kotlin/CommandHandlersPropertyTest.kt
@@ -28,16 +28,13 @@ class CommandHandlersPropertyTest : FunSpec({
                 
                 if (command.isNotEmpty() && deviceName.isNotEmpty()) {
                     val camelCommand = command.snakeToCamelCase()
-                    val device = Device.VirtualSwitch(1, "Test Device")
-                    
-                    whenever(deviceManager.findDevice(eq(deviceName), eq(camelCommand)))
-                        .thenReturn(Result.success(device))
-                    
-                    val mockResponse = mock<HttpResponse> {
-                        on { status } doReturn HttpStatusCode.OK
-                    }
-                    whenever(networkClient.get(any(), any())).thenReturn(mockResponse)
-                    
+
+                    // findDevice's contract is success-implies-supported, so an
+                    // arbitrary generated command must stub the failure path;
+                    // the property under test is the parsing, verified below.
+                    whenever(deviceManager.findDevice(any(), any()))
+                        .thenReturn(Result.failure(Exception("No device found for query: $deviceName")))
+
                     val messageText = "/$command $deviceName"
                     val message = mock<Message> {
                         on { text } doReturn messageText

--- a/src/test/kotlin/CommandHandlersTest.kt
+++ b/src/test/kotlin/CommandHandlersTest.kt
@@ -228,6 +228,42 @@ class CommandHandlersTest : FunSpec({
             result shouldBe "OK"
         }
 
+        test("trailing and doubled whitespace does not produce phantom device names") {
+            val message = mock<Message> {
+                on { text } doReturn "/on  kitchen  lights "
+            }
+            val device = Device.VirtualSwitch(1, "Kitchen Lights")
+            whenever(deviceManager.findDevice(any(), any()))
+                .thenReturn(Result.failure(Exception("No device found for query: probe")))
+            whenever(deviceManager.findDevice(eq("kitchen lights"), eq("on")))
+                .thenReturn(Result.success(device))
+
+            val mockResponse = mock<HttpResponse> {
+                on { status } doReturn HttpStatusCode.OK
+            }
+            whenever(networkClient.get(any(), any())).thenReturn(mockResponse)
+
+            val result = CommandHandlers.handleDeviceCommand(
+                bot, message, deviceManager, networkClient,
+                makerApiAppId, makerApiToken, defaultHubIp
+            )
+
+            result shouldBe "OK"
+        }
+
+        test("a command with only trailing whitespace asks for a device name") {
+            val message = mock<Message> {
+                on { text } doReturn "/on "
+            }
+
+            val result = CommandHandlers.handleDeviceCommand(
+                bot, message, deviceManager, networkClient,
+                makerApiAppId, makerApiToken, defaultHubIp
+            )
+
+            result shouldContain "Please specify a device name"
+        }
+
         test("reports the full query when no split matches a device") {
             val message = mock<Message> {
                 on { text } doReturn "/on unknown thing"

--- a/src/test/kotlin/CommandHandlersTest.kt
+++ b/src/test/kotlin/CommandHandlersTest.kt
@@ -65,6 +65,8 @@ class CommandHandlersTest : FunSpec({
                 on { text } doReturn "/push button 1 extra_arg"
             }
             val device = Device.VirtualButton(1, "Button")
+            whenever(deviceManager.findDevice(any(), any()))
+                .thenReturn(Result.failure(Exception("No device found for query: probe")))
             whenever(deviceManager.findDevice(eq("button"), eq("push")))
                 .thenReturn(Result.success(device))
             
@@ -126,6 +128,8 @@ class CommandHandlersTest : FunSpec({
                 on { text } doReturn "/push button 1"
             }
             val device = Device.VirtualButton(1, "Button")
+            whenever(deviceManager.findDevice(any(), any()))
+                .thenReturn(Result.failure(Exception("No device found for query: probe")))
             whenever(deviceManager.findDevice(eq("button"), eq("push")))
                 .thenReturn(Result.success(device))
 
@@ -144,6 +148,97 @@ class CommandHandlersTest : FunSpec({
         }
     }
     
+    context("handleDeviceCommand with multi-word device names") {
+        test("resolves a full multi-word name with no args") {
+            val message = mock<Message> {
+                on { text } doReturn "/on kitchen lights"
+            }
+            val device = Device.VirtualSwitch(1, "Kitchen Lights")
+            whenever(deviceManager.findDevice(any(), any()))
+                .thenReturn(Result.failure(Exception("No device found for query: probe")))
+            whenever(deviceManager.findDevice(eq("kitchen lights"), eq("on")))
+                .thenReturn(Result.success(device))
+
+            val mockResponse = mock<HttpResponse> {
+                on { status } doReturn HttpStatusCode.OK
+            }
+            whenever(networkClient.get(any(), any())).thenReturn(mockResponse)
+
+            val result = CommandHandlers.handleDeviceCommand(
+                bot, message, deviceManager, networkClient,
+                makerApiAppId, makerApiToken, defaultHubIp
+            )
+
+            result shouldBe "OK"
+        }
+
+        test("resolves a multi-word name followed by trailing args") {
+            val message = mock<Message> {
+                on { text } doReturn "/push front door button 1"
+            }
+            val device = Device.VirtualButton(7, "Front Door Button")
+            whenever(deviceManager.findDevice(any(), any()))
+                .thenReturn(Result.failure(Exception("No device found for query: probe")))
+            whenever(deviceManager.findDevice(eq("front door button"), eq("push")))
+                .thenReturn(Result.success(device))
+
+            val mockResponse = mock<HttpResponse> {
+                on { status } doReturn HttpStatusCode.OK
+            }
+            whenever(networkClient.get(argThat { contains("/devices/7/push/1") }, any()))
+                .thenReturn(mockResponse)
+
+            val result = CommandHandlers.handleDeviceCommand(
+                bot, message, deviceManager, networkClient,
+                makerApiAppId, makerApiToken, defaultHubIp
+            )
+
+            result shouldBe "OK"
+        }
+
+        test("prefers the longest matching name over a shorter prefix") {
+            val message = mock<Message> {
+                on { text } doReturn "/push master bedroom button 2"
+            }
+            val longer = Device.VirtualButton(2, "Master Bedroom Button")
+            val shorter = Device.VirtualButton(3, "Master")
+            whenever(deviceManager.findDevice(any(), any()))
+                .thenReturn(Result.failure(Exception("No device found for query: probe")))
+            whenever(deviceManager.findDevice(eq("master"), eq("push")))
+                .thenReturn(Result.success(shorter))
+            whenever(deviceManager.findDevice(eq("master bedroom button"), eq("push")))
+                .thenReturn(Result.success(longer))
+
+            val mockResponse = mock<HttpResponse> {
+                on { status } doReturn HttpStatusCode.OK
+            }
+            whenever(networkClient.get(argThat { contains("/devices/2/push/2") }, any()))
+                .thenReturn(mockResponse)
+
+            val result = CommandHandlers.handleDeviceCommand(
+                bot, message, deviceManager, networkClient,
+                makerApiAppId, makerApiToken, defaultHubIp
+            )
+
+            result shouldBe "OK"
+        }
+
+        test("reports the full query when no split matches a device") {
+            val message = mock<Message> {
+                on { text } doReturn "/on unknown thing"
+            }
+            whenever(deviceManager.findDevice(any(), any()))
+                .thenReturn(Result.failure(Exception("No device found for query: probe")))
+
+            val result = CommandHandlers.handleDeviceCommand(
+                bot, message, deviceManager, networkClient,
+                makerApiAppId, makerApiToken, defaultHubIp
+            )
+
+            result shouldBe "No device found for query: unknown thing"
+        }
+    }
+
     context("handleListCommand") {
         test("should return device list grouped by type") {
             val expectedMap = mapOf(

--- a/src/test/kotlin/CommandHandlersTest.kt
+++ b/src/test/kotlin/CommandHandlersTest.kt
@@ -97,9 +97,14 @@ class CommandHandlersTest : FunSpec({
             val message = mock<Message> {
                 on { text } doReturn "/invalid_command kitchen_light"
             }
-            val device = Device.VirtualSwitch(1, "Kitchen Light")
+            // findDevice signals an unsupported command with
+            // IllegalArgumentException, matching the real DeviceManager.
             whenever(deviceManager.findDevice(eq("kitchen_light"), eq("invalidCommand")))
-                .thenReturn(Result.success(device))
+                .thenReturn(
+                    Result.failure(
+                        IllegalArgumentException("Command 'invalidCommand' is not supported by device 'Kitchen Light'")
+                    )
+                )
 
             val result = CommandHandlers.handleDeviceCommand(
                 bot, message, deviceManager, networkClient,

--- a/src/test/kotlin/integration/CommandFlowIntegrationTest.kt
+++ b/src/test/kotlin/integration/CommandFlowIntegrationTest.kt
@@ -81,6 +81,43 @@ class CommandFlowIntegrationTest : FunSpec({
         result shouldBe "OK"
     }
     
+    test("device command flow - full multi-word device name") {
+        val mockEngine = MockEngine { request ->
+            when {
+                request.url.encodedPath.contains("/devices/1/on") -> {
+                    respond(content = ByteReadChannel(""), status = HttpStatusCode.OK)
+                }
+                else -> {
+                    respond(content = ByteReadChannel("Not found"), status = HttpStatusCode.NotFound)
+                }
+            }
+        }
+
+        val client = HttpClient(mockEngine)
+        val networkClient = KtorNetworkClient(client)
+        val deviceManager = DeviceManager(devicesJson)
+
+        val bot = mock<com.github.kotlintelegrambot.Bot>()
+        val message = Message(
+            messageId = 1,
+            date = 0,
+            chat = Chat(id = 123, type = "private"),
+            text = "/on Living Room Light" // Full name as documented in the README
+        )
+
+        val result = CommandHandlers.handleDeviceCommand(
+            bot = bot,
+            message = message,
+            deviceManager = deviceManager,
+            networkClient = networkClient,
+            makerApiAppId = "test-app",
+            makerApiToken = "test-token",
+            defaultHubIp = "192.168.1.100"
+        )
+
+        result shouldBe "OK"
+    }
+
     test("device command flow - device not found") {
         val mockEngine = MockEngine { request ->
             respond(


### PR DESCRIPTION
## Summary
- `handleDeviceCommand` took only `parts[1]` as the device name, so documented forms like `/on Kitchen Lights` and `/push Front Door Button 1` never worked. Closes #23
- New parsing: try the longest token prefix as the device name first, shrink until a cached device whose `supportedOps` arg count matches the trailing tokens; longest match wins, so `Master` can never steal `Master Bedroom Button`'s query
- Error precedence: arg-count mismatch > unsupported command > not found (reported against the full query)

## Test plan
- [x] `./gradlew test` green locally
- [x] New unit tests: full multi-word name, multi-word + trailing args, longest-match preference, not-found reporting
- [x] New integration test with real `DeviceManager`: `/on Living Room Light`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSb8VPARf1rMym2Bs72945