### PR TITLE
fix(robustness): reply on handler failures, check HTTP status, escape fence-breaking label chars

### DIFF
--- a/src/main/kotlin/CommandHandlers.kt
+++ b/src/main/kotlin/CommandHandlers.kt
@@ -202,12 +202,14 @@ object CommandHandlers {
             mapOf("access_token" to makerApiToken)
         )
         // A raw HTTP reason phrase ("Not Found") reads like noise, and a non-2xx
-        // used to be reported in the same voice as success. Say what happened.
+        // used to be reported in the same voice as success. Say what happened,
+        // in the snake_case form the user actually typed.
+        val displayCommand = command.camelToSnakeCase()
         val argSuffix = if (args.isEmpty()) "" else " ${args.joinToString(" ")}"
         return if (response.status.isSuccess()) {
-            "Done: ${device.label} → $command$argSuffix"
+            "Done: ${device.label} → $displayCommand$argSuffix"
         } else {
-            "Failed: ${device.label} → $command$argSuffix returned HTTP ${response.status}"
+            "Failed: ${device.label} → $displayCommand$argSuffix returned HTTP ${response.status}"
         }
     }
     

--- a/src/main/kotlin/CommandHandlers.kt
+++ b/src/main/kotlin/CommandHandlers.kt
@@ -3,6 +3,7 @@ package jbaru.ch.telegram.hubitat
 import com.github.kotlintelegrambot.Bot
 import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.Message
+import io.ktor.http.isSuccess
 import jbaru.ch.telegram.hubitat.model.Device
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -79,7 +80,11 @@ object CommandHandlers {
             "http://${defaultHubIp}/apps/api/${makerApiAppId}/hsm/cancelAlerts",
             mapOf("access_token" to makerApiToken)
         )
-        return response.status.description
+        return if (response.status.isSuccess()) {
+            "HSM alerts cancelled."
+        } else {
+            "Failed to cancel alerts: HTTP ${response.status}"
+        }
     }
     
     suspend fun handleGetOpenSensorsCommand(
@@ -196,7 +201,14 @@ object CommandHandlers {
             "http://${defaultHubIp}$fullPath",
             mapOf("access_token" to makerApiToken)
         )
-        return response.status.description
+        // A raw HTTP reason phrase ("Not Found") reads like noise, and a non-2xx
+        // used to be reported in the same voice as success. Say what happened.
+        val argSuffix = if (args.isEmpty()) "" else " ${args.joinToString(" ")}"
+        return if (response.status.isSuccess()) {
+            "Done: ${device.label} → $command$argSuffix"
+        } else {
+            "Failed: ${device.label} → $command$argSuffix returned HTTP ${response.status}"
+        }
     }
     
     private suspend fun getDeviceAttribute(

--- a/src/main/kotlin/DeviceManager.kt
+++ b/src/main/kotlin/DeviceManager.kt
@@ -76,8 +76,8 @@ class DeviceManager(deviceListJson: String) {
 
         // Group aliases by device and find maximum lengths
         deviceCache.forEach { (alias, device) ->
-            deviceToAliases.getOrPut(device) { mutableListOf() }.add(alias)
-            maxDeviceNameLength = maxOf(maxDeviceNameLength, device.label.length)
+            deviceToAliases.getOrPut(device) { mutableListOf() }.add(escapeMarkdownCode(alias))
+            maxDeviceNameLength = maxOf(maxDeviceNameLength, escapeMarkdownCode(device.label).length)
             maxAliasesLength = maxOf(maxAliasesLength, deviceToAliases[device]!!.joinToString(", ").length)
         }
 
@@ -95,7 +95,7 @@ class DeviceManager(deviceListJson: String) {
         deviceToAliases.forEach { (device, aliases) ->
             val aliasesString = aliases.joinToString(", ")
             tableBuilder.appendLine(
-                "| ${device.label.padEnd(maxDeviceNameLength)} | ${
+                "| ${escapeMarkdownCode(device.label).padEnd(maxDeviceNameLength)} | ${
                     aliasesString.padEnd(
                         maxAliasesLength
                     )
@@ -129,8 +129,8 @@ class DeviceManager(deviceListJson: String) {
             // Group aliases by device and find maximum lengths for this type
             deviceCache.forEach { (alias, device) ->
                 if (devices.contains(device)) {
-                    deviceToAliases.getOrPut(device) { mutableListOf() }.add(alias)
-                    maxDeviceNameLength = maxOf(maxDeviceNameLength, device.label.length)
+                    deviceToAliases.getOrPut(device) { mutableListOf() }.add(escapeMarkdownCode(alias))
+                    maxDeviceNameLength = maxOf(maxDeviceNameLength, escapeMarkdownCode(device.label).length)
                     maxAliasesLength = maxOf(maxAliasesLength, deviceToAliases[device]!!.joinToString(", ").length)
                 }
             }
@@ -147,7 +147,7 @@ class DeviceManager(deviceListJson: String) {
 
                 deviceToAliases.forEach { (device, aliases) ->
                     val aliasesString = aliases.joinToString(", ")
-                    appendLine("| ${device.label.padEnd(maxDeviceNameLength)} | ${aliasesString.padEnd(maxAliasesLength)} |")
+                    appendLine("| ${escapeMarkdownCode(device.label).padEnd(maxDeviceNameLength)} | ${aliasesString.padEnd(maxAliasesLength)} |")
                 }
 
                 appendLine("+" + "-".repeat(maxDeviceNameLength + 2) + "+" + "-".repeat(maxAliasesLength + 2) + "+")
@@ -200,6 +200,12 @@ class DeviceManager(deviceListJson: String) {
         deviceCache[key] = device
         return warnings
     }
+
+    // The /list tables render inside MarkdownV2 code fences, where every
+    // character is literal EXCEPT backslash and backtick - those two are the
+    // only ones that can break the fence and fail the whole sendMessage.
+    private fun escapeMarkdownCode(s: String): String =
+        s.replace("\\", "\\\\").replace("`", "\\`")
 
     private fun removeLightSuffix(name: String): String {
         return name.replace(Regex(" lights?$", RegexOption.IGNORE_CASE), "").trim()

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -153,7 +153,7 @@ fun main() {
                     }
                 } catch (e: Exception) {
                     logger.error("List command failed", e)
-                    bot.sendMessage(chatId = chatId, text = "Error listing devices: ${e.message ?: e.javaClass.simpleName}")
+                    bot.sendMessage(chatId = chatId, text = "Something went wrong listing devices. Check the bot logs for details.")
                 }
             }
 
@@ -234,7 +234,10 @@ private fun replyTo(bot: Bot, message: Message, block: suspend () -> String) {
         runBlocking { block() }
     } catch (e: Exception) {
         logger.error("Handler for '${message.text}' failed", e)
-        "Error handling '${message.text}': ${e.message ?: e.javaClass.simpleName}"
+        // Keep the details (URLs, stack) in the logs - exception messages can
+        // carry internals that don't belong in a chat reply.
+        val command = message.text?.split(" ")?.firstOrNull() ?: "command"
+        "Something went wrong handling $command. Check the bot logs for details."
     }
     bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = text)
 }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -64,28 +64,26 @@ fun main() {
 
             message(DeviceCommandFilter { deviceManager }) {
                 if (!isAuthorized(message)) return@message
-                val result = runBlocking {
+                replyTo(bot, message) {
                     CommandHandlers.handleDeviceCommand(
                         bot, message, deviceManager, networkClient,
                         config.makerApiAppId, config.makerApiToken, config.defaultHubIp
                     )
                 }
-                bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = result)
             }
 
             command("cancel_alerts") {
                 if (!isAuthorized(message)) return@command
-                val result = runBlocking {
+                replyTo(bot, message) {
                     CommandHandlers.handleCancelAlertsCommand(
                         networkClient, config.makerApiAppId, config.makerApiToken, config.defaultHubIp
                     )
                 }
-                bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = result)
             }
-            
+
             command("update") {
                 if (!isAuthorized(message)) return@command
-                val result = runBlocking {
+                replyTo(bot, message) {
                     HubOperations.updateHubsWithPolling(
                         hubs,
                         networkClient,
@@ -98,17 +96,16 @@ fun main() {
                                 text = progressMessage
                             )
                         }
+                    ).fold(
+                        onSuccess = { it },
+                        onFailure = {
+                            logger.error("Hub update failed", it)
+                            it.message.toString()
+                        }
                     )
                 }
-                bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = result.fold(
-                    onSuccess = { it },
-                    onFailure = {
-                        logger.error("Hub update failed", it)
-                        it.message.toString()
-                    }
-                ))
             }
-            
+
             command("firmware") {
                 if (!isAuthorized(message)) return@command
                 val chatId = ChatId.fromId(message.chat.id)
@@ -125,7 +122,7 @@ fun main() {
 
             command("refresh") {
                 if (!isAuthorized(message)) return@command
-                val refreshResults = runBlocking {
+                replyTo(bot, message) {
                     val results = CommandHandlers.handleRefreshCommand(
                         deviceManager, networkClient,
                         config.makerApiAppId, config.makerApiToken, config.defaultHubIp
@@ -136,71 +133,68 @@ fun main() {
                         deviceManager, networkClient, config.defaultHubIp,
                         config.makerApiAppId, config.makerApiToken
                     )
-                    results
+                    "Refresh finished, ${results.first} devices loaded. Warnings: ${results.second}"
                 }
-                bot.sendMessage(
-                    chatId = ChatId.fromId(message.chat.id),
-                    text = "Refresh finished, ${refreshResults.first} devices loaded. Warnings: ${refreshResults.second}"
-                )
             }
-            
+
             command("list") {
                 if (!isAuthorized(message)) return@command
                 val chatId = ChatId.fromId(message.chat.id)
-                val deviceLists = runBlocking {
-                    CommandHandlers.handleListCommand(deviceManager)
-                }
-                deviceLists.forEach { (type, table) ->
-                    bot.sendMessage(
-                        chatId = chatId,
-                        text = "*$type*:\n$table",
-                        parseMode = MARKDOWN_V2
-                    )
+                try {
+                    val deviceLists = runBlocking {
+                        CommandHandlers.handleListCommand(deviceManager)
+                    }
+                    deviceLists.forEach { (type, table) ->
+                        bot.sendMessage(
+                            chatId = chatId,
+                            text = "*$type*:\n$table",
+                            parseMode = MARKDOWN_V2
+                        )
+                    }
+                } catch (e: Exception) {
+                    logger.error("List command failed", e)
+                    bot.sendMessage(chatId = chatId, text = "Error listing devices: ${e.message ?: e.javaClass.simpleName}")
                 }
             }
 
             command("get_open_sensors") {
                 if (!isAuthorized(message)) return@command
-                val response = runBlocking {
+                replyTo(bot, message) {
                     CommandHandlers.handleGetOpenSensorsCommand(
                         deviceManager, networkClient,
                         config.makerApiAppId, config.makerApiToken, config.defaultHubIp
                     )
                 }
-                bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = response)
             }
-            
+
             command("get_mode") {
                 if (!isAuthorized(message)) return@command
-                val result = runBlocking {
+                replyTo(bot, message) {
                     CommandHandlers.handleGetModeCommand(
                         networkClient, config.makerApiAppId,
                         config.makerApiToken, config.defaultHubIp
                     )
                 }
-                bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = result)
             }
-            
+
             command("list_modes") {
                 if (!isAuthorized(message)) return@command
-                val result = runBlocking {
+                replyTo(bot, message) {
                     CommandHandlers.handleListModesCommand(
                         networkClient, config.makerApiAppId,
                         config.makerApiToken, config.defaultHubIp
                     )
                 }
-                bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = result)
             }
-            
+
             command("set_mode") {
                 if (!isAuthorized(message)) return@command
-                val result = runBlocking {
+                replyTo(bot, message) {
                     CommandHandlers.handleSetModeCommand(
                         message, networkClient, config.makerApiAppId,
                         config.makerApiToken, config.defaultHubIp
                     )
                 }
-                bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = result)
             }
         }
     }
@@ -229,6 +223,21 @@ private suspend fun getDevicesJson(): String =
         mapOf("access_token" to config.makerApiToken)
     )
 
+
+/**
+ * Runs a handler body and always answers the chat: an uncaught exception from
+ * a handler used to die inside the dispatcher, leaving the user staring at a
+ * bot that looks dead whenever the hub or network hiccuped.
+ */
+private fun replyTo(bot: Bot, message: Message, block: suspend () -> String) {
+    val text = try {
+        runBlocking { block() }
+    } catch (e: Exception) {
+        logger.error("Handler for '${message.text}' failed", e)
+        "Error handling '${message.text}': ${e.message ?: e.javaClass.simpleName}"
+    }
+    bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = text)
+}
 
 private fun isAuthorized(message: Message): Boolean {
     val allowed = config.isChatAllowed(message.chat.id)

--- a/src/main/kotlin/NetworkClient.kt
+++ b/src/main/kotlin/NetworkClient.kt
@@ -6,6 +6,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.contentType
+import io.ktor.http.isSuccess
 import org.slf4j.LoggerFactory
 
 interface NetworkClient {
@@ -30,6 +31,12 @@ class KtorNetworkClient(private val client: HttpClient) : NetworkClient {
     override suspend fun getBody(url: String, params: Map<String, String>): String {
         logger.info("HTTP GET (body): $url with params: ${redact(params)}")
         val response = get(url, params)
+        // An error page must never reach a JSON parser looking like data. Callers
+        // that expect mid-operation failures (hub rebooting during /update) catch
+        // this and treat it as "not ready yet".
+        if (!response.status.isSuccess()) {
+            throw IllegalStateException("GET $url failed: HTTP ${response.status}")
+        }
         val body = response.body<String>()
         if (isSecretResponse(url)) {
             logger.info("HTTP Response body (${body.length} chars): [REDACTED]")

--- a/src/main/kotlin/StringUtils.kt
+++ b/src/main/kotlin/StringUtils.kt
@@ -5,3 +5,7 @@ fun String.snakeToCamelCase(): String {
         if (index == 0) s else s.replaceFirstChar(Char::titlecase)
     }.joinToString("")
 }
+
+fun String.camelToSnakeCase(): String {
+    return replace(Regex("([a-z0-9])([A-Z])"), "$1_$2").lowercase()
+}

--- a/src/test/kotlin/CommandHandlersTest.kt
+++ b/src/test/kotlin/CommandHandlersTest.kt
@@ -44,7 +44,7 @@ class CommandHandlersTest : FunSpec({
                 makerApiAppId, makerApiToken, defaultHubIp
             )
             
-            result shouldBe "OK"
+            result shouldBe "Done: Kitchen Light → on"
         }
         
         test("should return error when command has missing arguments") {
@@ -140,7 +140,29 @@ class CommandHandlersTest : FunSpec({
                 makerApiAppId, makerApiToken, defaultHubIp
             )
 
-            result shouldBe "OK"
+            result shouldBe "Done: Button → push 1"
+        }
+
+        test("should report failure when the hub returns a non-2xx status") {
+            val message = mock<Message> {
+                on { text } doReturn "/on kitchen_light"
+            }
+            val device = Device.VirtualSwitch(1, "Kitchen Light")
+            whenever(deviceManager.findDevice(eq("kitchen_light"), eq("on")))
+                .thenReturn(Result.success(device))
+
+            val mockResponse = mock<HttpResponse> {
+                on { status } doReturn HttpStatusCode.NotFound
+            }
+            whenever(networkClient.get(any(), any())).thenReturn(mockResponse)
+
+            val result = CommandHandlers.handleDeviceCommand(
+                bot, message, deviceManager, networkClient,
+                makerApiAppId, makerApiToken, defaultHubIp
+            )
+
+            result shouldContain "Failed: Kitchen Light"
+            result shouldContain "404"
         }
     }
     
@@ -210,7 +232,7 @@ class CommandHandlersTest : FunSpec({
                 networkClient, makerApiAppId, makerApiToken, defaultHubIp
             )
             
-            result shouldBe "OK"
+            result shouldBe "HSM alerts cancelled."
         }
         
         test("should return error status when HSM command fails") {
@@ -223,7 +245,8 @@ class CommandHandlersTest : FunSpec({
                 networkClient, makerApiAppId, makerApiToken, defaultHubIp
             )
             
-            result shouldBe "Internal Server Error"
+            result shouldContain "Failed to cancel alerts"
+            result shouldContain "500"
         }
     }
     

--- a/src/test/kotlin/DeviceManagerTest.kt
+++ b/src/test/kotlin/DeviceManagerTest.kt
@@ -160,4 +160,22 @@ class DeviceManagerTest {
         assertEquals(1, count)
         assertTrue(warnings.any { it.startsWith("WARNING Skipping unsupported device") })
     }
+
+    @Test
+    fun `test list tables escape backtick and backslash in labels`() {
+        // The only two characters that can break a MarkdownV2 code fence.
+        val json = """
+            [
+                {"id": 1, "label": "Weird `Tick` Device", "type": "Virtual Switch"},
+                {"id": 2, "label": "Back\\slash Device", "type": "Virtual Switch"}
+            ]
+        """.trimIndent()
+
+        val tables = DeviceManager(json).listByType()
+        val actuators = tables.getValue("Actuators")
+
+        assertTrue(actuators.contains("Weird \\`Tick\\` Device"))
+        assertTrue(actuators.contains("Back\\\\slash Device"))
+        assertFalse(actuators.contains("Weird `Tick` Device"))
+    }
 }

--- a/src/test/kotlin/NetworkClientTest.kt
+++ b/src/test/kotlin/NetworkClientTest.kt
@@ -1,7 +1,9 @@
 package jbaru.ch.telegram.hubitat
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -32,6 +34,34 @@ class NetworkClientTest : FunSpec({
             )
 
             response.status shouldBe HttpStatusCode.OK
+        }
+
+        test("getBody returns the body on success") {
+            val mockEngine = MockEngine {
+                respond(
+                    content = ByteReadChannel("""{"status": "success"}"""),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf("Content-Type" to listOf("application/json"))
+                )
+            }
+
+            val client = KtorNetworkClient(HttpClient(mockEngine))
+            client.getBody("http://test.com/api") shouldBe """{"status": "success"}"""
+        }
+
+        test("getBody throws on a non-2xx status instead of returning the error page") {
+            val mockEngine = MockEngine {
+                respond(
+                    content = ByteReadChannel("<html>Not Found</html>"),
+                    status = HttpStatusCode.NotFound
+                )
+            }
+
+            val client = KtorNetworkClient(HttpClient(mockEngine))
+            val exception = shouldThrow<IllegalStateException> {
+                client.getBody("http://test.com/api")
+            }
+            exception.message shouldContain "404"
         }
     }
 

--- a/src/test/kotlin/StringUtilsTest.kt
+++ b/src/test/kotlin/StringUtilsTest.kt
@@ -24,4 +24,15 @@ class StringUtilsTest : FunSpec({
     test("snakeToCamelCase with consecutive underscores should handle empty tokens") {
         "hello__world".snakeToCamelCase() shouldBe "helloWorld"
     }
+
+    test("camelToSnakeCase converts camelCase back to snake_case") {
+        "setLevel".camelToSnakeCase() shouldBe "set_level"
+        "doubleTap".camelToSnakeCase() shouldBe "double_tap"
+        "on".camelToSnakeCase() shouldBe "on"
+        "".camelToSnakeCase() shouldBe ""
+    }
+
+    test("camelToSnakeCase round-trips snakeToCamelCase") {
+        "cancel_alerts".snakeToCamelCase().camelToSnakeCase() shouldBe "cancel_alerts"
+    }
 })

--- a/src/test/kotlin/integration/CommandFlowIntegrationTest.kt
+++ b/src/test/kotlin/integration/CommandFlowIntegrationTest.kt
@@ -78,7 +78,7 @@ class CommandFlowIntegrationTest : FunSpec({
             defaultHubIp = "192.168.1.100"
         )
         
-        result shouldBe "OK"
+        result shouldBe "Done: Living Room Light → on"
     }
     
     test("device command flow - device not found") {
@@ -179,7 +179,7 @@ class CommandFlowIntegrationTest : FunSpec({
             defaultHubIp = "192.168.1.100"
         )
         
-        result shouldBe "OK"
+        result shouldBe "HSM alerts cancelled."
     }
     
     test("get open sensors command flow - with open sensors") {


### PR DESCRIPTION
## Summary
Stacked on #34 (auto-retargets to `main` when it merges).

- `replyTo` wrapper around every single-reply handler: an uncaught exception used to die inside the dispatcher and the user got silence; now it's logged with stack and answered with a short error. Closes #26
- `runDeviceCommand` / `cancel_alerts` treat non-2xx as failure and reply with human text (`Done: Kitchen Light → on`, `Failed: … returned HTTP 404`) instead of raw HTTP reason phrases. Closes #27
- `NetworkClient.getBody` throws on non-2xx so error pages never reach a JSON parser looking like data (`/update`'s reboot-polling already treats that exception as "still rebooting", by design)
- `/list`: escape backtick and backslash in labels/aliases — the only two characters that are special inside a MarkdownV2 code fence. Note: contrary to #29's sibling report, `_`/`-`/`.` do NOT break `/list` — the tables live inside code fences where those are literal. Closes #28

## Test plan
- [x] `./gradlew test` green locally
- [x] New tests: non-2xx device command reply, cancel-alerts failure text, `getBody` throw on 404, fence-char escaping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSb8VPARf1rMym2Bs72945