### PR TITLE
feat(devices): /set_level for dimmers; README stops advertising unimplemented commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changes Log
 
+## /set_level for Dimmable Devices; README Stops Advertising Unimplemented Commands
+
+### Overview
+/set_level now actually works on dimmers and bulbs; the README no longer lists commands that never existed.
+
+### Changes Made
+- New Dimmer device family (Room Lights Activator Dimmer/Bulb, Zooz dimmers) supporting on/off/setLevel - "/set_level Kitchen Lights 50" works end to end
+- /set_color and /set_color_temperature removed from the README: no color-capable device type exists
+
+### Benefits
+- Documented commands and implemented commands are the same set again
+
 ## Boot No Longer Hangs on Irreconcilable Device-Name Abbreviations
 
 ### Overview

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@
   * `/off [device name]` - Turns off a specified device.
   * `/open [device name]` - Opens a specified device (e.g., shades).
   * `/close [device name]` - Closes a specified device.
-  * `/set_color [device name] [color]` - Sets the color of a compatible device.
-  * `/set_color_temperature [device name] [temperature]` - Sets the color temperature of a compatible device.
-  * `/set_level [device name] [level]` - Sets the level of a dimmable device.
+  * `/set_level [device name] [level]` - Sets the level (0-100) of a dimmable device (dimmers and bulbs).
   * `/double_tap [device name]` - Executes a double tap action on a button device.
   * `/push [device name]` - Executes a push action on a button device.
   * `/hold [device name]` - Executes a hold action on a button device.

--- a/src/main/kotlin/model/Device.kt
+++ b/src/main/kotlin/model/Device.kt
@@ -3,6 +3,18 @@
 package jbaru.ch.telegram.hubitat.model
 import kotlinx.serialization.*
 
+// Shared constants behind the getter-only overrides: the getters keep these
+// type-level tables out of serialization, the constants keep every access from
+// allocating a fresh map.
+private val ACTUATOR_OPS = mapOf("on" to 0, "off" to 0)
+private val DIMMER_OPS = mapOf("on" to 0, "off" to 0, "setLevel" to 1)
+private val BUTTON_OPS = mapOf("doubleTap" to 1, "hold" to 1, "push" to 1, "release" to 1)
+private val SHADE_OPS = mapOf("open" to 0, "close" to 0)
+private val HUB_OPS = mapOf("reboot" to 0)
+private val CONTACT_ATTRIBUTES = mapOf("contact" to listOf("open", "closed"))
+private val NO_OPS = emptyMap<String, Int>()
+private val NO_ATTRIBUTES = emptyMap<String, List<String>>()
+
 @Serializable
 sealed class Device {
     abstract val id: Int
@@ -12,31 +24,36 @@ sealed class Device {
 
     @Serializable
     sealed class Actuator() : Device() {
-        override val supportedOps: Map<String, Int> = mapOf("on" to 0, "off" to 0)
-        override val attributes: Map<String, List<String>> = emptyMap()
+        override val supportedOps: Map<String, Int> get() = ACTUATOR_OPS
+        override val attributes: Map<String, List<String>> get() = NO_ATTRIBUTES
 
+    }
+
+    @Serializable
+    sealed class Dimmer() : Actuator() {
+        override val supportedOps: Map<String, Int> get() = DIMMER_OPS
     }
 
     @Serializable
     sealed class Button() : Device() {
-        override val supportedOps: Map<String, Int> = mapOf("doubleTap" to 1, "hold" to 1, "push" to 1, "release" to 1)
-        override val attributes: Map<String, List<String>> = emptyMap()
+        override val supportedOps: Map<String, Int> get() = BUTTON_OPS
+        override val attributes: Map<String, List<String>> get() = NO_ATTRIBUTES
     }
 
     @Serializable
     sealed class Shade() : Device() {
-        override val supportedOps: Map<String, Int> = mapOf("open" to 0, "close" to 0)
-        override val attributes: Map<String, List<String>> = emptyMap()
+        override val supportedOps: Map<String, Int> get() = SHADE_OPS
+        override val attributes: Map<String, List<String>> get() = NO_ATTRIBUTES
     }
 
     @Serializable
     sealed class Sensor() : Device() {
-        override val supportedOps: Map<String, Int> = emptyMap()
+        override val supportedOps: Map<String, Int> get() = NO_OPS
     }
 
     @Serializable
     sealed class ContactSensor() : Sensor() {
-        override val attributes: Map<String, List<String>> = mapOf("contact" to listOf("open", "closed"))
+        override val attributes: Map<String, List<String>> get() = CONTACT_ATTRIBUTES
     }
 
     @Serializable
@@ -55,8 +72,8 @@ sealed class Device {
         var managementToken: String = "",
         var ip: String = ""
     ) : Device() {
-        override val supportedOps: Map<String, Int> = mapOf("reboot" to 0)
-        override val attributes: Map<String, List<String>> = emptyMap()
+        override val supportedOps: Map<String, Int> get() = HUB_OPS
+        override val attributes: Map<String, List<String>> get() = NO_ATTRIBUTES
     }
 
     @Serializable
@@ -73,11 +90,11 @@ sealed class Device {
 
     @Serializable
     @SerialName("Room Lights Activator Dimmer")
-    data class RoomLightsActivatorDimmer(override val id: Int, override val label: String) : Actuator()
+    data class RoomLightsActivatorDimmer(override val id: Int, override val label: String) : Dimmer()
 
     @Serializable
     @SerialName("Room Lights Activator Bulb")
-    data class RoomLightsActivatorBulb(override val id: Int, override val label: String) : Actuator()
+    data class RoomLightsActivatorBulb(override val id: Int, override val label: String) : Dimmer()
 
     @Serializable
     @SerialName("Generic Zigbee Outlet")
@@ -85,11 +102,11 @@ sealed class Device {
 
     @Serializable
     @SerialName("Zooz Zen27 Central Scene Dimmer")
-    data class ZoozDimmer(override val id: Int, override val label: String) : Actuator()
+    data class ZoozDimmer(override val id: Int, override val label: String) : Dimmer()
 
     @Serializable
     @SerialName("Zooz ZEN Dimmer Advanced")
-    data class ZoozZenDimmerAdvanced(override val id: Int, override val label: String) : Actuator()
+    data class ZoozZenDimmerAdvanced(override val id: Int, override val label: String) : Dimmer()
 
     @Serializable
     @SerialName("Zooz Zen76 S2 Switch")

--- a/src/test/kotlin/CommandHandlersTest.kt
+++ b/src/test/kotlin/CommandHandlersTest.kt
@@ -152,6 +152,30 @@ class CommandHandlersTest : FunSpec({
             result shouldBe "Done: Button → push 1"
         }
 
+        test("should execute set_level on a dimmer") {
+            val message = mock<Message> {
+                on { text } doReturn "/set_level kitchen 50"
+            }
+            val device = Device.RoomLightsActivatorDimmer(5, "Kitchen Lights")
+            whenever(deviceManager.findDevice(any(), any()))
+                .thenReturn(Result.failure(Exception("No device found for query: probe")))
+            whenever(deviceManager.findDevice(eq("kitchen"), eq("setLevel")))
+                .thenReturn(Result.success(device))
+
+            val mockResponse = mock<HttpResponse> {
+                on { status } doReturn HttpStatusCode.OK
+            }
+            whenever(networkClient.get(argThat { contains("/devices/5/setLevel/50") }, any()))
+                .thenReturn(mockResponse)
+
+            val result = CommandHandlers.handleDeviceCommand(
+                bot, message, deviceManager, networkClient,
+                makerApiAppId, makerApiToken, defaultHubIp
+            )
+
+            result shouldBe "Done: Kitchen Lights → set_level 50"
+        }
+
         test("should report failure when the hub returns a non-2xx status") {
             val message = mock<Message> {
                 on { text } doReturn "/on kitchen_light"

--- a/src/test/kotlin/DeviceManagerTest.kt
+++ b/src/test/kotlin/DeviceManagerTest.kt
@@ -162,6 +162,20 @@ class DeviceManagerTest {
     }
 
     @Test
+    fun `test dimmer supports setLevel and plain switch does not`() {
+        // Kitchen Lights is a Room Lights Activator Dimmer in the fixture.
+        val dimmer = deviceManager.findDevice("Kitchen Lights", "setLevel")
+        assertTrue(dimmer.isSuccess)
+
+        val switch = deviceManager.findDevice("Garage Door", "setLevel")
+        assertTrue(switch.isFailure)
+        assertEquals(
+            "Command 'setLevel' is not supported by device 'Garage Door'",
+            switch.exceptionOrNull()?.message
+        )
+    }
+
+    @Test
     fun `test refresh updates the device command set`() {
         // Boot with only sensors: no actuator commands exist yet.
         val sensorsOnly = """


### PR DESCRIPTION
## Summary
Stacked on #39.

- New sealed `Device.Dimmer` (`on`/`off`/`setLevel`) for the four dimmable driver types — `/set_level kitchen 50` now works end to end. Type-level `supportedOps`/`attributes` become getter-only properties (kotlinx.serialization rejects subclass backing-field re-declaration, and they were never data). Closes #30
- `/set_color` and `/set_color_temperature` removed from the README — no color-capable device type exists; advertising them was documentation fiction. If color devices land later, the commands come back with an implementation attached.

## Test plan
- [x] `./gradlew test` green locally
- [x] New tests: dimmer accepts `setLevel`, plain switch rejects it, `/set_level` handler flow builds `/devices/5/setLevel/50`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSb8VPARf1rMym2Bs72945