### PR TITLE
ci(review): add jbaruch/coding-policy PR review setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 # Copy to .env (which is gitignored) and fill in real values.
 # Consumed by docker-compose.yml for variable substitution.
+#
+# The GitHub Actions secret below (FLEET_DISPATCH_TOKEN) is NOT copied to .env —
+# set it as a repo secret at:
+#   https://github.com/jbaruch/tg-hubitat-bot/settings/secrets/actions
 
 # Telegram bot token from @BotFather
 BOT_TOKEN=
@@ -12,3 +16,9 @@ CHAT_ID=
 DEFAULT_HUB_IP=hubitat.local
 # Image tag to run; deploy.sh sets this to the build version
 TAG=latest
+
+# --- GitHub Actions secret (set in repo Settings → Secrets, not .env) ---
+# FLEET_DISPATCH_TOKEN — fine-grained PAT scoped to only jbaruch/coding-policy
+#   (Actions: write). Lets .github/workflows/review-trigger.yml dispatch the
+#   central fleet policy review. Settings link is in the header above.
+FLEET_DISPATCH_TOKEN=

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# Copilot code review — scope
+
+This repository is reviewed by a separate policy reviewer — the central `jbaruch/coding-policy`
+fleet reviewer (a scheduled GitHub App that reviews every PR against the installed
+`jbaruch/coding-policy` rules, enrolled via the `.github/fleet-review-enabled` marker). It owns
+conventions and policy. **Your job is the complementary lane: correctness and risk.**
+Spend your review budget where the policy reviewer does not look.
+
+## Review for
+- Logic errors, wrong conditions, off-by-one, incorrect edge-case handling.
+- Race conditions, ordering bugs, non-idempotent retries, lost updates.
+- Resource leaks (unclosed files/connections), unbounded growth, needless recompute on hot paths.
+- Missing or wrong error handling that lets a real failure pass silently or crash — not stylistic preference.
+- Security: injection, unsafe deserialization, authz gaps, secrets in code or logs, unvalidated untrusted input.
+- Test coverage gaps: a changed branch or failure path with no test; an assertion that would pass even if the code were wrong.
+
+## Do NOT comment on (the policy reviewer owns these)
+- Naming/style conventions, formatting, import order.
+- Commit-message or PR-title format, changelog entries, branch naming.
+- Rule/policy compliance, doc structure, skill/rule authoring conventions.
+- Restating project rules — assume they are enforced by the policy reviewer.
+
+## Repo facts (avoid false positives)
+- Verify a tool's real semantics before flagging — prefer a missed bug over a confident false positive.

--- a/.github/fleet-review-enabled
+++ b/.github/fleet-review-enabled
@@ -1,0 +1,9 @@
+# Opts this repository into the central jbaruch/coding-policy policy reviewer.
+#
+# The coding-policy-fleet-reviewer GitHub App (installed on this account) runs a
+# scheduled poller in jbaruch/coding-policy that reviews every open pull request
+# in each repo carrying this marker, against the jbaruch/coding-policy rules,
+# using the OpenAI Codex CLI on a ChatGPT subscription. No per-repo workflow or
+# secret is needed — the credential lives only in coding-policy.
+#
+# Remove this file to opt out. See https://github.com/jbaruch/coding-policy.

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -1,0 +1,50 @@
+name: Trigger fleet policy review
+
+# PR-time trigger for the central jbaruch/coding-policy fleet reviewer. On every
+# same-repo PR event this fires a single-PR review in coding-policy immediately,
+# so the policy verdict is available before merge (the coding-policy cron poll is
+# only a backstop). Fork PRs are skipped — they cannot read the dispatch secret.
+# Dependabot PRs are skipped too — the dependabot actor gets no secrets, so the
+# dispatch could never authenticate (the cron poll backstop still reviews them).
+#
+# Requires one repo secret (set it at
+# https://github.com/<owner>/<repo>/settings/secrets/actions for this repo):
+#   FLEET_DISPATCH_TOKEN — a fine-grained PAT scoped to ONLY jbaruch/coding-policy
+#     with `Actions: write` (nothing else). It can trigger the review workflow and
+#     nothing more. The Codex credential itself lives only in coding-policy.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+concurrency:
+  group: trigger-fleet-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  trigger:
+    # Fork PRs cannot read secrets — skip them (adopt via the adopt-fork-pr skill).
+    # Dependabot's actor also gets no secrets, so its dispatch can't authenticate —
+    # skip it too (the coding-policy cron poll reviews dependabot PRs instead).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch the single-PR review to coding-policy
+        env:
+          GH_TOKEN: ${{ secrets.FLEET_DISPATCH_TOKEN }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.pull_request.number }}
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "error: FLEET_DISPATCH_TOKEN secret is empty — set a fine-grained PAT (Actions: write on jbaruch/coding-policy only); see this workflow's header" >&2
+            exit 1
+          fi
+          gh workflow run fleet-review.yml \
+            --repo jbaruch/coding-policy \
+            -f repo="$REPO" -f pr="$PR" -f base="$BASE"


### PR DESCRIPTION
Enrolls `tg-hubitat-bot` in the central `jbaruch/coding-policy` fleet policy reviewer. This PR commits only the reviewer wiring — no source changes.

## What this PR commits, and who reviews

- `.github/workflows/review-trigger.yml` — a thin `on: pull_request` workflow that fires an **immediate single-PR review** in `jbaruch/coding-policy` (via `gh workflow run`), so the policy verdict lands before merge. Holds no Codex credential — only a narrow dispatch token. (Fork PRs and Dependabot PRs are skipped — they can't read the secret / get no secrets; the poll backstop covers them.)
- `.github/fleet-review-enabled` — the opt-in marker. Enrolls this repo in the central `coding-policy-fleet-reviewer` App's scheduled poll (the backstop). The review runs against the `jbaruch/coding-policy` rules with the OpenAI Codex CLI on a **ChatGPT subscription** (no API key); the verdict posts as a `<app-slug>[bot]` review.
- `.github/copilot-instructions.md` — scopes Copilot to the complementary lane (correctness, bugs, security, test gaps) and off policy.

The fleet reviewer is the policy reviewer; Copilot is the code-quality reviewer. Both gate the merge.

## Operator secret — one narrow token

The Codex credential lives only in `jbaruch/coding-policy`. This repo needs **one** secret so the trigger can reach it:

- `FLEET_DISPATCH_TOKEN` — a **fine-grained PAT scoped to only `jbaruch/coding-policy`** with `Actions: write` (nothing else). Set it at Settings → Secrets and variables → Actions **before the first PR after merge**, or the PR-time review won't fire (the scheduled poll still would).

## Load indicator

The fleet review's summary begins `Policy loaded: N rule files from jbaruch/coding-policy.` and each finding names the violated rule in bold (e.g. `**ci-safety**`). Seeing the `Policy loaded:` line confirms the poller's `tessl install` loaded the policy; a summary without it signals the install step didn't run.

---
Companion to #35 (adds `coding-policy` to `tessl.json`). Scaffolded via the `install-reviewer` skill on `coding-policy@0.3.110`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGeBDNcz72DVw61VTphuCm