### PR TITLE
chore(release): bump version to 3.12

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "jbaru.ch"
-version = "3.11"
+version = "3.12"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Summary
Version bump for the review-fixes release: chat allowlist (#22), slash-only + mention-validated commands (#29), multi-word device names (#23), abbreviator hang fix (#24) + progress-scan follow-up, refresh consistency (#25, #31), handler error replies + HTTP status checking (#26, #27, #28), /set_level (#30), parallel fault-tolerant scans + secret-redacted logging (#33).

## Test plan
- [x] `./gradlew test` green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSb8VPARf1rMym2Bs72945