### PR TITLE
chore(detekt): exception hygiene (33 → 16)

### DIFF
--- a/src/main/kotlin/jbaru/ch/telegram/hubitat/BotConfiguration.kt
+++ b/src/main/kotlin/jbaru/ch/telegram/hubitat/BotConfiguration.kt
@@ -19,15 +19,18 @@ data class BotConfiguration(
         allowedChatIds.isEmpty() || chatId in allowedChatIds
 
     companion object {
+        private fun requiredEnv(name: String): String =
+            getenv(name) ?: throw IllegalStateException("$name not set")
+
         fun fromEnvironment(): BotConfiguration {
             // Trimmed so the stored value matches what the allowlist validated -
             // an untrimmed value would pass validation here and still crash the
             // startup-message toLong() later.
             val chatId = (getenv("CHAT_ID") ?: "").trim()
             return BotConfiguration(
-                botToken = getenv("BOT_TOKEN") ?: throw IllegalStateException("BOT_TOKEN not set"),
-                makerApiAppId = getenv("MAKER_API_APP_ID") ?: throw IllegalStateException("MAKER_API_APP_ID not set"),
-                makerApiToken = getenv("MAKER_API_TOKEN") ?: throw IllegalStateException("MAKER_API_TOKEN not set"),
+                botToken = requiredEnv("BOT_TOKEN"),
+                makerApiAppId = requiredEnv("MAKER_API_APP_ID"),
+                makerApiToken = requiredEnv("MAKER_API_TOKEN"),
                 chatId = chatId,
                 defaultHubIp = getenv("DEFAULT_HUB_IP") ?: "hubitat.local",
                 allowedChatIds = parseAllowedChatIds(chatId, getenv("ALLOWED_CHAT_IDS"))

--- a/src/main/kotlin/jbaru/ch/telegram/hubitat/DeviceManager.kt
+++ b/src/main/kotlin/jbaru/ch/telegram/hubitat/DeviceManager.kt
@@ -32,6 +32,10 @@ class DeviceManager(deviceListJson: String) {
         refreshDevices(deviceListJson)
     }
 
+    // Per-device resilience: any decode failure - unknown type, missing field,
+    // serializer quirk - skips that device with a warning instead of taking
+    // the whole list (and the bot) down at boot.
+    @Suppress("TooGenericExceptionCaught")
     @Synchronized
     fun refreshDevices(deviceListJson: String): Pair<Int, List<String>> {
         val format = Json { ignoreUnknownKeys = true }

--- a/src/main/kotlin/jbaru/ch/telegram/hubitat/FirmwareOperations.kt
+++ b/src/main/kotlin/jbaru/ch/telegram/hubitat/FirmwareOperations.kt
@@ -64,6 +64,7 @@ object FirmwareOperations {
     internal const val CATALOG_URL =
         "https://raw.githubusercontent.com/jbaruch/tg-hubitat-bot/main/src/main/resources/zwave-firmware-catalog.json"
     private const val MAX_MESSAGE_LENGTH = 3900
+    private const val ZWAVE_NODE_ID_RADIX = 16
 
     fun loadCatalog(): FirmwareCatalog {
         val resource = FirmwareOperations::class.java.getResourceAsStream(CATALOG_RESOURCE)
@@ -77,6 +78,9 @@ object FirmwareOperations {
      * bot redeploy. The bundled copy is the offline fallback, and the report
      * header says so when it is used.
      */
+    // Any failure here - network, HTTP, malformed JSON - must fall back to the
+    // bundled catalog rather than kill /firmware; the note in the report says so.
+    @Suppress("TooGenericExceptionCaught")
     suspend fun fetchCatalog(networkClient: NetworkClient): Pair<FirmwareCatalog, String?> =
         try {
             json.decodeFromString<FirmwareCatalog>(networkClient.getBody(CATALOG_URL)) to null
@@ -85,6 +89,9 @@ object FirmwareOperations {
             loadCatalog() to "bundled fallback — live catalog unreachable"
         }
 
+    // Per-hub resilience: one unreachable hub becomes a report line, not a
+    // dead /firmware command - whatever it threw.
+    @Suppress("TooGenericExceptionCaught")
     suspend fun checkFirmware(
         hubs: List<Device.Hub>,
         networkClient: NetworkClient
@@ -188,22 +195,27 @@ object FirmwareOperations {
         )
 
         if (info.firmwareVersion == null) {
-            val nodeId = base.dni.toIntOrNull(16)
-                ?: throw IllegalStateException(
-                    "driver reports no firmware version and DNI '${base.dni}' is not a Z-Wave node id"
-                )
-            val details = Json.parseToJsonElement(
-                networkClient.getBody("http://${hub.ip}/hub/zwave/deviceFirmware/details?nodeId=$nodeId")
-            ).jsonObject
-            if (details["success"]?.jsonPrimitive?.booleanOrNull != true) {
-                throw IllegalStateException("deviceFirmware/details failed for node $nodeId")
-            }
-            val version = details["targets"]?.jsonArray?.firstOrNull()
-                ?.jsonObject?.get("version")?.jsonPrimitive?.content
-                ?: throw IllegalStateException("deviceFirmware/details returned no targets for node $nodeId")
-            info = info.copy(firmwareVersion = version)
+            info = info.copy(firmwareVersion = fetchZwaveJsVersion(zwaveJsNodeId(base), hub, networkClient))
         }
         return info
+    }
+
+    private fun zwaveJsNodeId(base: ZwaveDeviceInfo): Int =
+        base.dni.toIntOrNull(ZWAVE_NODE_ID_RADIX)
+            ?: throw IllegalStateException(
+                "driver reports no firmware version and DNI '${base.dni}' is not a Z-Wave node id"
+            )
+
+    private suspend fun fetchZwaveJsVersion(nodeId: Int, hub: Device.Hub, networkClient: NetworkClient): String {
+        val details = Json.parseToJsonElement(
+            networkClient.getBody("http://${hub.ip}/hub/zwave/deviceFirmware/details?nodeId=$nodeId")
+        ).jsonObject
+        if (details["success"]?.jsonPrimitive?.booleanOrNull != true) {
+            throw IllegalStateException("deviceFirmware/details failed for node $nodeId")
+        }
+        return details["targets"]?.jsonArray?.firstOrNull()
+            ?.jsonObject?.get("version")?.jsonPrimitive?.content
+            ?: throw IllegalStateException("deviceFirmware/details returned no targets for node $nodeId")
     }
 
     fun classify(device: ZwaveDeviceInfo, catalog: FirmwareCatalog): FirmwareFinding {

--- a/src/main/kotlin/jbaru/ch/telegram/hubitat/HubOperations.kt
+++ b/src/main/kotlin/jbaru/ch/telegram/hubitat/HubOperations.kt
@@ -2,6 +2,7 @@ package jbaru.ch.telegram.hubitat
 
 import io.ktor.http.HttpStatusCode
 import jbaru.ch.telegram.hubitat.model.Device
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.jsonObject
@@ -37,9 +38,13 @@ object HubOperations {
     // Anything shorter cannot be a real hub-info JSON payload - it is a hub
     // mid-restart answering with a stub.
     private const val MIN_PLAUSIBLE_RESPONSE_LENGTH = 10
+    private const val PREVIEW_LENGTH = 200
 
     private val logger = LoggerFactory.getLogger(HubOperations::class.java)
 
+    // Per-hub resilience: a hub that cannot be initialized is skipped with a
+    // warning - whatever it threw - so one bad hub never blocks startup.
+    @Suppress("TooGenericExceptionCaught")
     suspend fun initializeHubs(
         deviceManager: DeviceManager,
         networkClient: NetworkClient,
@@ -84,6 +89,20 @@ object HubOperations {
         return initialized
     }
     
+    private fun validateHubInfoResponse(hub: Device.Hub, endpoint: String, responseBody: String) {
+        val problem = when {
+            responseBody.isBlank() ->
+                "Received empty response. This may happen if the hub is busy or restarting."
+            responseBody.length < MIN_PLAUSIBLE_RESPONSE_LENGTH ->
+                "Received incomplete response (${responseBody.length} chars): '$responseBody'. " +
+                    "This may happen if the hub is busy, restarting, or experiencing network issues."
+            else -> return
+        }
+        throw IllegalStateException(
+            "Failed to get hub info for hub '${hub.label}' from endpoint '$endpoint': $problem"
+        )
+    }
+
     suspend fun getHubVersions(
         hub: Device.Hub,
         networkClient: NetworkClient,
@@ -95,21 +114,7 @@ object HubOperations {
         val endpoint = "http://${hubIp}/apps/api/${makerApiAppId}/devices/${hub.id}"
         val responseBody = networkClient.getBody(endpoint, mapOf("access_token" to makerApiToken))
         
-        // Check for empty or very short response (likely incomplete)
-        if (responseBody.isBlank()) {
-            throw Exception(
-                "Failed to get hub info for hub '${hub.label}' from endpoint '$endpoint': " +
-                "Received empty response. This may happen if the hub is busy or restarting."
-            )
-        }
-        
-        if (responseBody.length < MIN_PLAUSIBLE_RESPONSE_LENGTH) {
-            throw Exception(
-                "Failed to get hub info for hub '${hub.label}' from endpoint '$endpoint': " +
-                "Received incomplete response (${responseBody.length} chars): '$responseBody'. " +
-                "This may happen if the hub is busy, restarting, or experiencing network issues."
-            )
-        }
+        validateHubInfoResponse(hub, endpoint, responseBody)
         
         try {
             val json = Json.parseToJsonElement(responseBody).jsonObject
@@ -125,16 +130,30 @@ object HubOperations {
             }?.jsonObject?.get("currentValue")?.jsonPrimitive?.content ?: ""
             
             return Pair(currentVersion, availableVersion)
-        } catch (e: Exception) {
-            val preview = if (responseBody.length > 200) responseBody.take(200) + "..." else responseBody
-            throw Exception(
-                "Failed to parse hub info response for hub '${hub.label}' from endpoint '$endpoint': ${e.message}\n" +
-                "Response preview: $preview",
-                e
-            )
+        } catch (e: SerializationException) {
+            throw hubInfoParseError(hub, endpoint, responseBody, e)
+        } catch (e: IllegalArgumentException) {
+            throw hubInfoParseError(hub, endpoint, responseBody, e)
         }
     }
+
+    private fun hubInfoParseError(
+        hub: Device.Hub,
+        endpoint: String,
+        responseBody: String,
+        e: Exception
+    ): IllegalStateException {
+        val preview =
+            if (responseBody.length > PREVIEW_LENGTH) responseBody.take(PREVIEW_LENGTH) + "..." else responseBody
+        return IllegalStateException(
+                "Failed to parse hub info response for hub '${hub.label}' from endpoint '$endpoint': ${e.message}\n" +
+                    "Response preview: $preview",
+            e
+        )
+    }
     
+    // Per-hub resilience: a failed request becomes a per-hub status line.
+    @Suppress("TooGenericExceptionCaught")
     suspend fun updateHubs(
         hubs: List<Device.Hub>,
         networkClient: NetworkClient
@@ -167,6 +186,10 @@ object HubOperations {
         }
     }
     
+    // The poll loop treats ANY read failure as "hub still rebooting" by design
+    // (see the comment inside); narrowing the catch would turn expected reboot
+    // blips into failed updates.
+    @Suppress("TooGenericExceptionCaught")
     suspend fun updateHubsWithPolling(
         hubs: List<Device.Hub>,
         networkClient: NetworkClient,

--- a/src/main/kotlin/jbaru/ch/telegram/hubitat/Main.kt
+++ b/src/main/kotlin/jbaru/ch/telegram/hubitat/Main.kt
@@ -49,6 +49,10 @@ private lateinit var deviceManager: DeviceManager
 // Resolved via getMe() at startup; used to validate /cmd@BotName mentions.
 @Volatile private var botUsername: String? = null
 
+// The /firmware and /list handlers hold dispatcher-boundary catch-alls (they
+// send multiple messages, so they cannot use replyTo); same outer-boundary
+// contract as replyTo below.
+@Suppress("TooGenericExceptionCaught")
 fun main() {
     config = BotConfiguration.fromEnvironment()
     networkClient = KtorNetworkClient(client)
@@ -257,6 +261,7 @@ private suspend fun getDevicesJson(): String =
  * a handler used to die inside the dispatcher, leaving the user staring at a
  * bot that looks dead whenever the hub or network hiccuped.
  */
+@Suppress("TooGenericExceptionCaught") // outer-boundary contract below
 private fun replyTo(bot: Bot, message: Message, block: suspend () -> String) {
     val text = try {
         runBlocking { block() }

--- a/src/main/kotlin/jbaru/ch/telegram/hubitat/ModeOperations.kt
+++ b/src/main/kotlin/jbaru/ch/telegram/hubitat/ModeOperations.kt
@@ -14,6 +14,9 @@ data class ModeInfo(
 object ModeOperations {
     private val json = Json { ignoreUnknownKeys = true }
     
+    // Result-boundary: any failure - network, HTTP, JSON - becomes
+    // Result.failure for the caller to fold into a chat reply.
+    @Suppress("TooGenericExceptionCaught")
     suspend fun getAllModes(
         networkClient: NetworkClient,
         makerApiAppId: String,
@@ -45,6 +48,8 @@ object ModeOperations {
             }
     }
     
+    // Result-boundary: any failure becomes Result.failure for the caller.
+    @Suppress("TooGenericExceptionCaught")
     suspend fun setMode(
         networkClient: NetworkClient,
         makerApiAppId: String,


### PR DESCRIPTION
## Summary
Stacked on #47. Second detekt-adoption PR.

- `throw Exception(...)` → `IllegalStateException` in `HubOperations` (3)
- `ThrowsCount` fixed by extraction: `requiredEnv()` in `BotConfiguration`, `validateHubInfoResponse` in `getHubVersions`, `zwaveJsNodeId`/`fetchZwaveJsVersion` in `FirmwareOperations` (3)
- `getHubVersions`' parse catch narrowed to `SerializationException`/`IllegalArgumentException` (1)
- The 12 remaining catch-alls are **deliberate resilience boundaries** (per-device decode skip, per-hub init/update, catalog fallback, Result boundaries, dispatcher boundaries) — each now carries `@Suppress("TooGenericExceptionCaught")` with its justification at the site. Narrowing them would convert expected per-item failures into whole-command failures, which is exactly what #26/#33 fixed.

Remaining 16 findings (LongMethod/Cyclomatic/ReturnCount/TooManyFunctions) are structural and come in the next PR.

## Test plan
- [x] `./gradlew test` green
- [x] `./gradlew detekt`: 33 → 16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSb8VPARf1rMym2Bs72945