### PR TITLE
chore(detekt): wire the CI gate — tree at zero findings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -219,12 +219,10 @@ tasks.named("jibBuildTar") {
 
 
 // Static-analysis tooling. detekt 2.0.0-alpha.5 supports the JVM 25 toolchain
-// (1.23.x caps at jvmTarget 22). Run on demand with `./gradlew detekt`.
-// No CI gate yet: per language-diagnostics "Adopting on a Dirty Tree", the gate
-// is wired only once the tree reports zero findings — fixes land first, in
-// separate PRs, then a final PR adds the CI step.
+// (1.23.x caps at jvmTarget 22). The tree is at zero findings and detekt sits
+// on the `check` lifecycle (the plugin default), so CI's gradle build gates on
+// it - a new finding fails the build.
 detekt {
     buildUponDefaultConfig = true
     config.setFrom(files("config/detekt/detekt.yml"))
 }
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -228,12 +228,3 @@ detekt {
     config.setFrom(files("config/detekt/detekt.yml"))
 }
 
-// Adoption phase: keep detekt OFF the `check`/`build` lifecycle so CI stays
-// green while the tree is still dirty. The plugin auto-wires `:detekt` into
-// `check`; detach it so it runs on demand only (`./gradlew detekt`). The gate PR
-// re-attaches it once findings reach zero.
-tasks.named("check") {
-    setDependsOn(dependsOn.filterNot {
-        (it as? TaskProvider<*>)?.name?.startsWith("detekt") == true
-    })
-}


### PR DESCRIPTION
## Summary
Stacked on #49. Final detekt-adoption PR, per #46's plan (fixes first, gate last).

- Removes the adoption-phase detach that kept `:detekt` off the `check` lifecycle; `./gradlew build` (what CI runs) now gates on detekt
- Verified: `:detekt` appears in the `check` task graph and the tree reports zero findings

The whole arc: **147 findings → 0** across #47 (mechanical), #48 (exceptions), #49 (structure), with two documented rule tunings (`excludeRawStrings` for JSON fixtures, `ReturnCount max: 4` for guard-clause style).

## Test plan
- [x] `./gradlew check` green with `:detekt` in the graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSb8VPARf1rMym2Bs72945