### PR TITLE
Map Generic Component Switch, a multi-outlet plug's outlet

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 }
 
 group = "jbaru.ch"
-version = "3.12"
+version = "3.13"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/jbaru/ch/telegram/hubitat/model/Device.kt
+++ b/src/main/kotlin/jbaru/ch/telegram/hubitat/model/Device.kt
@@ -121,6 +121,13 @@ sealed class Device {
     @SerialName("Zooz ZEN Plugs Advanced")
     data class ZoozZenPlugsAdvanced(override val id: Int, override val label: String) : Actuator()
 
+    // The driver a multi-outlet plug's per-endpoint children get. On a ZEN14 double plug the
+    // parent's `switch` is an OR of both outlets, so the child is the only device that reflects
+    // one outlet -- and the only one worth naming after whatever is plugged into it.
+    @Serializable
+    @SerialName("Generic Component Switch")
+    data class GenericComponentSwitch(override val id: Int, override val label: String) : Actuator()
+
     @Serializable
     @SerialName("Room Lights Activator Shade")
     data class RoomLightsActivatorShade(override val id: Int, override val label: String) : Shade()

--- a/src/test/kotlin/jbaru/ch/telegram/hubitat/DeviceManagerTest.kt
+++ b/src/test/kotlin/jbaru/ch/telegram/hubitat/DeviceManagerTest.kt
@@ -127,6 +127,32 @@ class DeviceManagerTest {
     }
 
     @Test
+    fun `test generic component switch is controllable`() {
+        // A multi-outlet plug's per-endpoint children carry this driver. Before it was mapped the
+        // child loaded as an unknown type and was skipped -- so the outlet the lights are actually
+        // on was invisible to the bot, while its parent plug stayed controllable and switched BOTH
+        // outlets. Same device names as the live hub, deliberately.
+        val json = """
+            [
+                {"id": 612, "label": "Backyard Plug", "type": "Zooz ZEN Plugs Advanced"},
+                {"id": 1684, "label": "Backyard String Lights", "type": "Generic Component Switch"}
+            ]
+        """.trimIndent()
+
+        val manager = DeviceManager(json)
+        val (count, warnings) = manager.refreshDevices(json)
+
+        assertEquals(2, count)
+        assertTrue(warnings.isEmpty())
+
+        val lights = manager.findDevice("Backyard String Lights", "on")
+        assertTrue(lights.isSuccess)
+        assertEquals(1684, lights.getOrNull()?.id)
+        // off too -- reaching the outlet instead of the plug is the whole point.
+        assertTrue(manager.findDevice("Backyard String Lights", "off").isSuccess)
+    }
+
+    @Test
     fun `test unknown device type is skipped with a warning instead of crashing`() {
         // A newly-installed driver with no @Serializable subclass must not take
         // the whole device list (and the bot) down at boot.


### PR DESCRIPTION
## Why

A Zooz ZEN14 outdoor **double** plug on the hub had never had its per-outlet child devices created. Creating them gave the backyard string lights their own device — and the bot could not see it.

Per-endpoint children get Hubitat's built-in **Generic Component Switch** driver, which had no `@Serializable` subclass. `refreshDevices` handled that gracefully (skip + warning, thanks to the existing unknown-type guard), so nothing crashed — the outlet was simply invisible to the bot while its parent plug stayed controllable.

## Why the parent isn't good enough

On a double plug the parent's `switch` is an **OR of both outlets**:

- Commanding the parent switches **both** outlets, not the one the lights are on.
- Reading the parent cannot tell you the lights went dark — with the other outlet energised it still reports `on`.

The child is the only device that corresponds to what is physically plugged in.

## Change

One `@SerialName("Generic Component Switch")` subclass of `Actuator`. `Actuator` is the correct parent: Maker API reports `on`, `off`, `refresh` for the child, and `ACTUATOR_OPS` is exactly `on`/`off`.

## Verification

`./gradlew test detekt` — **207 tests, 0 failures**, detekt clean at its zero-findings gate.

New test uses the live hub's real device names and asserts the specific regression: both devices load with **no** warnings, and the child resolves for `on` and `off`. Before the change it loaded as an unknown type and `findDevice` failed — the existing `test unknown device type is skipped with a warning` test still covers that path for genuinely unmapped drivers.

## AI Disclosure

This change was prepared with the assistance of Claude Code. The driver-type gap was found by tracing why a newly created child device was absent from the bot; the code, test, and this description were AI-drafted and verified with the full test and detekt gates. Reviewed by the human contributor before submission.